### PR TITLE
Completely rework persistent state

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 ---
 Language: Cpp
 # BasedOnStyle: Chromium
-AccessModifierOffset: -2
+AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
 AlignConsecutiveBitFields: Consecutive

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ find_rodos()
 
 add_library(Sts1CobcSw_Dummy OBJECT)
 add_library(Sts1CobcSw_Hal INTERFACE)
-add_library(Sts1CobcSw_Periphery INTERFACE)
+add_library(Sts1CobcSw_Periphery OBJECT)
 add_library(Sts1CobcSw_Serial INTERFACE)
 add_library(Sts1CobcSw_Utility INTERFACE)
 add_program(HelloDummy)

--- a/Sts1CobcSw/CMakeLists.txt
+++ b/Sts1CobcSw/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(Hal)
+add_subdirectory(Periphery)
 add_subdirectory(Serial)
 add_subdirectory(Utility)
 

--- a/Sts1CobcSw/Hal/GpioPin.hpp
+++ b/Sts1CobcSw/Hal/GpioPin.hpp
@@ -22,7 +22,7 @@ enum class PinState
 
 class GpioPin
 {
-  public:
+public:
     // Implicit conversion from GPIO_PIN is very convenient (see Gpio.test.cpp)
     // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
     GpioPin(RODOS::GPIO_PIN pinIndex);
@@ -32,7 +32,7 @@ class GpioPin
     auto Reset() -> void;
     auto Read() const -> PinState;
 
-  private:
+private:
     mutable RODOS::HAL_GPIO pin_;
 };
 

--- a/Sts1CobcSw/Periphery/CMakeLists.txt
+++ b/Sts1CobcSw/Periphery/CMakeLists.txt
@@ -1,0 +1,2 @@
+target_sources(Sts1CobcSw_Periphery PRIVATE PersistentState.cpp)
+target_link_libraries(Sts1CobcSw_Periphery PUBLIC type_safe)

--- a/Sts1CobcSw/Periphery/PersistentState.cpp
+++ b/Sts1CobcSw/Periphery/PersistentState.cpp
@@ -1,0 +1,118 @@
+#include <Sts1CobcSw/Periphery/PersistentState.hpp>
+
+
+// This is just a dummy implementation that does not store anything in a persistent memory.
+namespace sts1cobcsw::periphery::persistentstate
+{
+namespace ts = type_safe;
+
+using ts::operator""_i8;
+using ts::operator""_i32;
+
+// TODO: Think about how large the types really need to be
+// TODO: Maybe use std::optionl<T> or just have an isInitialized flag or something
+// Bootloader stuff
+auto notOkCounter = -1_i8;         // NOLINT(cert-err58-cpp)
+auto activeFirmwareImage = -1_i8;  // NOLINT(cert-err58-cpp)
+auto backupFirmwareImage = -1_i8;  // NOLINT(cert-err58-cpp)
+
+// COBC state
+ts::bool_t antennasShouldBeDeployed = true;
+ts::bool_t txIsOn = true;
+ts::bool_t eduShouldBePowered = false;
+auto utcOffset = 0_i32;  // NOLINT(cert-err58-cpp)
+
+// TODO: Add thresholds
+
+
+auto Initialize() -> void
+{
+    // Load all variables from FRAM
+}
+
+
+// Getters
+[[nodiscard]] auto NotOkCounter() -> type_safe::int8_t
+{
+    return notOkCounter;
+}
+
+
+[[nodiscard]] auto ActiveFirmwareImage() -> type_safe::int8_t
+{
+    return activeFirmwareImage;
+}
+
+
+[[nodiscard]] auto BackupFirmwareImage() -> type_safe::int8_t
+{
+    return backupFirmwareImage;
+}
+
+
+[[nodiscard]] auto AntennasShouldBeDeployed() -> type_safe::bool_t
+{
+    return antennasShouldBeDeployed;
+}
+
+
+[[nodiscard]] auto TxIsOn() -> type_safe::bool_t
+{
+    return txIsOn;
+}
+
+
+[[nodiscard]] auto EduShouldBePowered() -> type_safe::bool_t
+{
+    return eduShouldBePowered;
+}
+
+
+[[nodiscard]] auto UtcOffset() -> type_safe::int32_t
+{
+    return utcOffset;
+}
+
+
+// Setters
+auto NotOkCounter(type_safe::int8_t value) -> void
+{
+    notOkCounter = value;
+}
+
+
+auto ActiveFirmwareImage(type_safe::int8_t value) -> void
+{
+    activeFirmwareImage = value;
+}
+
+
+auto BackupFirmwareImage(type_safe::int8_t value) -> void
+{
+    backupFirmwareImage = value;
+}
+
+
+auto AntennasShouldBeDeployed(type_safe::bool_t value) -> void
+{
+    antennasShouldBeDeployed = value;
+}
+
+
+auto TxIsOn(type_safe::bool_t value) -> void
+{
+    txIsOn = value;
+}
+
+
+auto EduShouldBePowered(type_safe::bool_t value) -> void
+{
+    eduShouldBePowered = value;
+}
+
+
+auto UtcOffset(type_safe::int32_t value) -> void
+{
+    utcOffset = value;
+}
+}

--- a/Sts1CobcSw/Periphery/PersistentState.hpp
+++ b/Sts1CobcSw/Periphery/PersistentState.hpp
@@ -7,7 +7,7 @@ namespace sts1cobcsw::periphery
 template<typename T>
 class PersistentState
 {
-  public:
+public:
     PersistentState() = delete;
     explicit PersistentState(T const & t);
     ~PersistentState() = default;
@@ -19,7 +19,7 @@ class PersistentState
     [[nodiscard]] auto Get() const -> T;
     auto Set(T const & t) -> void;
 
-  private:
+private:
     T value_;
 };
 

--- a/Sts1CobcSw/Periphery/PersistentState.hpp
+++ b/Sts1CobcSw/Periphery/PersistentState.hpp
@@ -1,45 +1,34 @@
 #pragma once
 
 
-namespace sts1cobcsw::periphery
+#include <type_safe/types.hpp>
+
+#include <cstdint>
+
+
+// This is just a dummy implementation that does not store anything in a persistent memory.
+namespace sts1cobcsw::periphery::persistentstate
 {
-// This is just a dummy implementation now that does not store anything in a persistent memory.
-template<typename T>
-class PersistentState
-{
-public:
-    PersistentState() = delete;
-    explicit PersistentState(T const & t);
-    ~PersistentState() = default;
-    PersistentState(PersistentState const &) = delete;
-    auto operator=(PersistentState const &) -> PersistentState & = delete;
-    PersistentState(PersistentState &&) = delete;
-    auto operator=(PersistentState &&) -> PersistentState & = delete;
+// Must be called once in a thread's init() function
+auto Initialize() -> void;
 
-    [[nodiscard]] auto Get() const -> T;
-    auto Set(T const & t) -> void;
+// Getters
+[[nodiscard]] auto NotOkCounter() -> type_safe::int8_t;
+[[nodiscard]] auto ActiveFirmwareImage() -> type_safe::int8_t;
+[[nodiscard]] auto BackupFirmwareImage() -> type_safe::int8_t;
 
-private:
-    T value_;
-};
+[[nodiscard]] auto AntennasShouldBeDeployed() -> type_safe::bool_t;
+[[nodiscard]] auto TxIsOn() -> type_safe::bool_t;
+[[nodiscard]] auto EduShouldBePowered() -> type_safe::bool_t;
+[[nodiscard]] auto UtcOffset() -> type_safe::int32_t;
 
+// Setters
+auto NotOkCounter(type_safe::int8_t) -> void;
+auto ActiveFirmwareImage(type_safe::int8_t) -> void;
+auto BackupFirmwareImage(type_safe::int8_t) -> void;
 
-template<typename T>
-PersistentState<T>::PersistentState(T const & t) : value_{t}
-{
-}
-
-
-template<typename T>
-auto PersistentState<T>::Get() const -> T
-{
-    return value_;
-}
-
-
-template<typename T>
-auto PersistentState<T>::Set(T const & t) -> void
-{
-    value_ = t;
-}
+auto AntennasShouldBeDeployed(type_safe::bool_t) -> void;
+auto TxIsOn(type_safe::bool_t) -> void;
+auto EduShouldBePowered(type_safe::bool_t) -> void;
+auto UtcOffset(type_safe::int32_t) -> void;
 }

--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -3,7 +3,7 @@ target_link_libraries(Sts1CobcSwTests_Dummy PRIVATE Catch2::Catch2WithMain Sts1C
 
 add_program(PersistentState PersistentState.test.cpp)
 target_link_libraries(
-    Sts1CobcSwTests_PersistentState PRIVATE Catch2::Catch2WithMain Sts1CobcSw_Utility
+    Sts1CobcSwTests_PersistentState PRIVATE Catch2::Catch2WithMain Sts1CobcSw_Periphery
 )
 
 add_program(Serial Serial.test.cpp)

--- a/Tests/UnitTests/PersistentState.test.cpp
+++ b/Tests/UnitTests/PersistentState.test.cpp
@@ -1,27 +1,49 @@
+// Only the current dummy implementation can be a unit test. The real implementation will be a
+// hardware test.
+
 #include <Sts1CobcSw/Periphery/PersistentState.hpp>
 
 #include <catch2/catch_test_macros.hpp>
+#include <type_safe/types.hpp>
 
 #include <type_traits>
 
 
-using sts1cobcsw::periphery::PersistentState;
+namespace ps = sts1cobcsw::periphery::persistentstate;
 
 
-TEST_CASE("PersistentState is non-default constructible, non-copyable and non-moveable")
+TEST_CASE("Persistent state getters and setters")
 {
-    REQUIRE(not std::is_default_constructible_v<PersistentState<char>>);
-    REQUIRE(not std::is_copy_constructible_v<PersistentState<short>>);
-    REQUIRE(not std::is_copy_assignable_v<PersistentState<int>>);
-    REQUIRE(not std::is_move_constructible_v<PersistentState<float>>);
-    REQUIRE(not std::is_move_assignable_v<PersistentState<double>>);
-}
+    using type_safe::operator""_i8;
+    using type_safe::operator""_i32;
 
+    ps::Initialize();
 
-TEST_CASE("Get() and Set()")
-{
-    PersistentState<int> persistentInt(13);
-    REQUIRE(persistentInt.Get() == 13);
-    persistentInt.Set(-273);
-    REQUIRE(persistentInt.Get() == -273);
+    // .get() and == true/false are only used because the Catch2 magic can't handle type_safe
+    // numbers
+
+    ps::NotOkCounter(13_i8);
+    REQUIRE(ps::NotOkCounter().get() == 13);
+
+    ps::ActiveFirmwareImage(5_i8);
+    REQUIRE(ps::ActiveFirmwareImage().get() == 5);
+
+    ps::BackupFirmwareImage(9_i8);
+    REQUIRE(ps::BackupFirmwareImage().get() == 9);
+
+    ps::AntennasShouldBeDeployed(false);
+    REQUIRE(ps::AntennasShouldBeDeployed() == false);
+
+    ps::TxIsOn(false);
+    REQUIRE(ps::TxIsOn() == false);
+    ps::TxIsOn(true);
+    REQUIRE(ps::TxIsOn() == true);
+
+    ps::EduShouldBePowered(true);
+    REQUIRE(ps::EduShouldBePowered() == true);
+    ps::EduShouldBePowered(false);
+    REQUIRE(ps::EduShouldBePowered() == false);
+
+    ps::UtcOffset(13579);
+    REQUIRE(ps::UtcOffset().get() == 13579);
 }


### PR DESCRIPTION
Every variable has its own specific getter and setter function now. It is also no longer a class because it doesn't need to be. Due to Rodos "enforcing" the use of global variables that must be initialized in some thread's `init()` the advantage of classes, which is establishing an invariant during construction, is no longer there.