### PR TITLE
Separate status and history from EDU program queue

### DIFF
--- a/Sts1CobcSw/EduListenerThread.cpp
+++ b/Sts1CobcSw/EduListenerThread.cpp
@@ -20,14 +20,11 @@
 
 namespace sts1cobcsw
 {
-constexpr auto timeLoopPeriod = 1 * RODOS::SECONDS;
-
 // Can't use auto here since GCC throws an error about conflicting declarations otherwise :(
 hal::GpioPin eduUpdateGpioPin(hal::eduUpdatePin);
 
 
-auto FindStatusHistoryEntry(std::uint16_t programId, std::uint16_t queueId)
-    -> StatusHistoryEntry;
+constexpr auto timeLoopPeriod = 1 * RODOS::SECONDS;
 
 
 class EduListenerThread : public StaticThread<>
@@ -80,6 +77,7 @@ private:
                     // RODOS::PRINTF("[EduListenerThread] Call to GetStatus() resulted in
                     // success.\n");
                 }
+
 
                 switch(status.statusType)
                 {
@@ -138,6 +136,7 @@ private:
                             FindStatusHistoryEntry(status.programId, status.queueId);
                         statusHistoryEntry.status = ProgramStatus::resultFileTransfered;
 
+
                         break;
                     }
 
@@ -152,19 +151,4 @@ private:
         }
     }
 } eduListenerThread;
-
-
-auto FindStatusAndHistoryEntry(std::uint16_t programId, std::uint16_t queueId) -> StatusHistoryEntry
-{
-    auto counter = 0;
-    auto statusHistoryEntry = StatusHistoryEntry{};
-    do
-    {
-        statusHistory.get(statusHistoryEntry);
-        // RODOS::PRINTF("%d,%d vs %d,%d\n", statusHistoryEntry.programId,
-        // statusHistoryEntry.queueId, programId, queueId);
-    } while(statusHistoryEntry.queueId != queueId or statusHistoryEntry.programId != programId);
-
-    return statusHistoryEntry;
-}
 }

--- a/Sts1CobcSw/EduListenerThread.cpp
+++ b/Sts1CobcSw/EduListenerThread.cpp
@@ -2,6 +2,7 @@
 #include <Sts1CobcSw/EduListenerThread.hpp>
 #include <Sts1CobcSw/EduProgramQueue.hpp>
 #include <Sts1CobcSw/EduProgramQueueThread.hpp>
+#include <Sts1CobcSw/EduProgramStatusHistory.hpp>
 #include <Sts1CobcSw/Hal/IoNames.hpp>
 #include <Sts1CobcSw/Hal/PinNames.hpp>
 #include <Sts1CobcSw/Periphery/Edu.hpp>
@@ -23,20 +24,6 @@ hal::GpioPin eduUpdateGpioPin(hal::eduUpdatePin);
 
 
 constexpr auto timeLoopPeriod = 1 * RODOS::SECONDS;
-
-auto FindStatusAndHistoryEntry(std::uint16_t programId, std::uint16_t queueId) -> StatusHistoryEntry
-{
-    auto counter = 0;
-    auto statusHistoryEntry = StatusHistoryEntry{};
-    do
-    {
-        statusHistory.get(statusHistoryEntry);
-        // RODOS::PRINTF("%d,%d vs %d,%d\n", statusHistoryEntry.programId,
-        // statusHistoryEntry.queueId, programId, queueId);
-    } while(statusHistoryEntry.queueId != queueId or statusHistoryEntry.programId != programId);
-
-    return statusHistoryEntry;
-}
 
 
 class EduListenerThread : public StaticThread<>
@@ -100,7 +87,7 @@ private:
                         // thread
 
                         auto statusHistoryEntry =
-                            FindStatusAndHistoryEntry(status.programId, status.queueId);
+                            FindStatusHistoryEntry(status.programId, status.queueId);
 
                         if(status.exitCode == 0)
                         {
@@ -145,7 +132,7 @@ private:
                         // break;
 
                         auto statusHistoryEntry =
-                            FindStatusAndHistoryEntry(status.programId, status.queueId);
+                            FindStatusHistoryEntry(status.programId, status.queueId);
                         statusHistoryEntry.status = ProgramStatus::resultFileTransfered;
 
 

--- a/Sts1CobcSw/EduProgramQueue.cpp
+++ b/Sts1CobcSw/EduProgramQueue.cpp
@@ -7,5 +7,4 @@ namespace sts1cobcsw
 {
 std::uint16_t queueIndex = 0U;
 etl::vector<EduQueueEntry, eduProgramQueueSize> eduProgramQueue{};
-RODOS::RingBuffer<StatusHistoryEntry, statusHistorySize> statusHistory{};
 }

--- a/Sts1CobcSw/EduProgramQueue.hpp
+++ b/Sts1CobcSw/EduProgramQueue.hpp
@@ -58,35 +58,8 @@ inline auto DeserializeFrom(Byte * source, EduQueueEntry * data) -> Byte *
 }
 
 
-// TODO: Move the status and history related stuff to its own StatusAndHistory.hpp
-enum class ProgramStatus : uint8_t
-{
-    programRunning,
-    programCouldNotBeStarted,
-    programExecutionFailed,
-    programExecutionSucceeded,
-    resultFileTransfered,
-    resultFileSentToRf,
-    ackFromGround,
-    resultFileDeleted
-};
-
-
-struct StatusHistoryEntry
-{
-    ts::uint16_t programId = 0_u16;
-    ts::uint16_t queueId = 0_u16;
-    ProgramStatus status = ProgramStatus::programRunning;
-};
-
 inline constexpr auto eduProgramQueueSize = 20;
-// TODO: Think about the name. Maybe something like program/queueStatusAndHistory is better?
-inline constexpr auto statusHistorySize = 20;
 
-// TODO: Why is this defined in EduProgramQueueThread.cpp and not EduProgramQueue.cpp?
 extern uint16_t queueIndex;
 extern etl::vector<EduQueueEntry, eduProgramQueueSize> eduProgramQueue;
-// TODO: Maybe move that to its own file? Together with the definition of StatusHistoryEntry of
-// course.
-extern RODOS::RingBuffer<StatusHistoryEntry, statusHistorySize> statusHistory;
 }

--- a/Sts1CobcSw/EduProgramQueueThread.cpp
+++ b/Sts1CobcSw/EduProgramQueueThread.cpp
@@ -1,6 +1,7 @@
 #include <Sts1CobcSw/EduCommunicationErrorThread.hpp>
 #include <Sts1CobcSw/EduProgramQueue.hpp>
 #include <Sts1CobcSw/EduProgramQueueThread.hpp>
+#include <Sts1CobcSw/EduProgramStatusHistory.hpp>
 #include <Sts1CobcSw/Periphery/EduEnums.hpp>
 #include <Sts1CobcSw/Periphery/EduStructs.hpp>
 #include <Sts1CobcSw/ThreadPriorities.hpp>

--- a/Sts1CobcSw/EduProgramStatusHistory.cpp
+++ b/Sts1CobcSw/EduProgramStatusHistory.cpp
@@ -19,4 +19,3 @@ auto FindStatusHistoryEntry(std::uint16_t programId, std::uint16_t queueId) -> S
     return statusHistoryEntry;
 }
 }
-

--- a/Sts1CobcSw/EduProgramStatusHistory.cpp
+++ b/Sts1CobcSw/EduProgramStatusHistory.cpp
@@ -1,0 +1,22 @@
+#include <Sts1CobcSw/EduProgramStatusHistory.hpp>
+
+#include <rodos.h>
+
+
+namespace sts1cobcsw
+{
+
+auto FindStatusHistoryEntry(std::uint16_t programId, std::uint16_t queueId) -> StatusHistoryEntry
+{
+    auto statusHistoryEntry = StatusHistoryEntry{};
+    do
+    {
+        statusHistory.get(statusHistoryEntry);
+        // RODOS::PRINTF("%d,%d vs %d,%d\n", statusHistoryEntry.programId,
+        // statusHistoryEntry.queueId, programId, queueId);
+    } while(statusHistoryEntry.queueId != queueId or statusHistoryEntry.programId != programId);
+
+    return statusHistoryEntry;
+}
+}
+

--- a/Sts1CobcSw/EduProgramStatusHistory.hpp
+++ b/Sts1CobcSw/EduProgramStatusHistory.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <cstdint>
+#include <type_safe/types.hpp>
 
 #include <ringbuffer.h>
 
-#include <type_safe/types.hpp>
+#include <cstdint>
 
 namespace sts1cobcsw
 {

--- a/Sts1CobcSw/EduProgramStatusHistory.hpp
+++ b/Sts1CobcSw/EduProgramStatusHistory.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+
+#include <ringbuffer.h>
+
+#include <type_safe/types.hpp>
+
+namespace sts1cobcsw
+{
+namespace ts = type_safe;
+using ts::operator""_u16;
+
+
+enum class ProgramStatus : uint8_t
+{
+    programRunning,
+    programCouldNotBeStarted,
+    programExecutionFailed,
+    programExecutionSucceeded,
+    resultFileTransfered,
+    resultFileSentToRf,
+    ackFromGround,
+    resultFileDeleted
+};
+
+
+struct StatusHistoryEntry
+{
+    ts::uint16_t programId = 0_u16;
+    ts::uint16_t queueId = 0_u16;
+    ProgramStatus status = ProgramStatus::programRunning;
+};
+
+// TODO: Think about the name. Maybe something like program/queueStatusAndHistory is better?
+inline constexpr auto statusHistorySize = 20;
+
+RODOS::RingBuffer<StatusHistoryEntry, statusHistorySize> statusHistory;
+
+auto FindStatusHistoryEntry(std::uint16_t programId, std::uint16_t queueId) -> StatusHistoryEntry;
+}


### PR DESCRIPTION
Moves related code from `EduListenerThread` and `EduProgramQueue` into `EduProgramStatusHistory`, which fixes #51 and closes #50, which was left open by accident