### PR TITLE
Separate status and history from EDU program queue

### DIFF
--- a/Sts1CobcSw/CMakeLists.txt
+++ b/Sts1CobcSw/CMakeLists.txt
@@ -14,12 +14,12 @@ target_link_libraries(Sts1CobcSw_Dummy PUBLIC etl::etl)
 target_sources(Sts1CobcSw_HelloDummy PRIVATE HelloDummy.cpp)
 target_link_libraries(Sts1CobcSw_HelloDummy PRIVATE Sts1CobcSw_Dummy rodos::rodos)
 
-#target_sources(Sts1CobcSw_Heartbeat PRIVATE EduHeartbeatThread.cpp TopicsAndSubscribers.cpp)
-#target_link_libraries(Sts1CobcSw_Heartbeat PRIVATE etl::etl rodos::rodos type_safe Sts1CobcSw_Hal Sts1CobcSw_Utility Sts1CobcSw_Periphery)
-
+# target_sources(Sts1CobcSw_Heartbeat PRIVATE EduHeartbeatThread.cpp TopicsAndSubscribers.cpp)
+# target_link_libraries(Sts1CobcSw_Heartbeat PRIVATE etl::etl rodos::rodos type_safe Sts1CobcSw_Hal
+# Sts1CobcSw_Utility Sts1CobcSw_Periphery)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Generic)
-    #if(FALSE)
+    # if(FALSE)
     target_sources(
         Sts1CobcSw_CobcSw
         PRIVATE CommandParserThread.cpp
@@ -27,6 +27,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Generic)
                 EduPowerManagementThread.cpp
                 EduProgramQueue.cpp
                 EduProgramQueueThread.cpp
+                EduProgramStatusHistory.cpp
                 TopicsAndSubscribers.cpp
                 EduCommunicationErrorThread.cpp
                 EduListenerThread.cpp

--- a/Sts1CobcSw/EduListenerThread.cpp
+++ b/Sts1CobcSw/EduListenerThread.cpp
@@ -84,10 +84,8 @@ private:
                         // Program has finished
                         // Find the correspongind queueEntry and update it, then resume edu queue
                         // thread
-
                         auto eduProgramStatusHistoryEntry =
                             FindEduProgramStatusHistoryEntry(status.programId, status.queueId);
-
                         if(status.exitCode == 0)
                         {
                             eduProgramStatusHistoryEntry.status =
@@ -99,10 +97,8 @@ private:
                                 EduProgramStatus::programExecutionFailed;
                         }
                         ResumeEduProgramQueueThread();
-
                         break;
                     }
-
                     case periphery::EduStatusType::resultsReady:
                     {
                         // Edu wants to send result file
@@ -110,7 +106,6 @@ private:
                         // update the S&H Entry from 3 or 4 to 5.
                         auto resultsInfo = edu.ReturnResult();
                         auto errorCode = resultsInfo.errorCode;
-
                         if(errorCode != periphery::EduErrorCode::success
                            and errorCode != periphery::EduErrorCode::successEof)
                         {
@@ -134,12 +129,12 @@ private:
 
                         auto eduProgramStatusHistoryEntry =
                             FindEduProgramStatusHistoryEntry(status.programId, status.queueId);
+                        // TODO: Pretty sure that there is a .put() or something like that missing
+                        // here and the status is actually never updated in the ring buffer.
                         eduProgramStatusHistoryEntry.status =
                             EduProgramStatus::resultFileTransfered;
-
                         break;
                     }
-
                     case periphery::EduStatusType::invalid:
                     case periphery::EduStatusType::noEvent:
                     {

--- a/Sts1CobcSw/EduListenerThread.cpp
+++ b/Sts1CobcSw/EduListenerThread.cpp
@@ -85,16 +85,18 @@ private:
                         // Find the correspongind queueEntry and update it, then resume edu queue
                         // thread
 
-                        auto statusHistoryEntry =
-                            FindStatusAndHistoryEntry(status.programId, status.queueId);
+                        auto eduProgramStatusHistoryEntry =
+                            FindEduProgramStatusHistoryEntry(status.programId, status.queueId);
 
                         if(status.exitCode == 0)
                         {
-                            statusHistoryEntry.status = ProgramStatus::programExecutionSucceeded;
+                            eduProgramStatusHistoryEntry.status =
+                                EduProgramStatus::programExecutionSucceeded;
                         }
                         else
                         {
-                            statusHistoryEntry.status = ProgramStatus::programExecutionFailed;
+                            eduProgramStatusHistoryEntry.status =
+                                EduProgramStatus::programExecutionFailed;
                         }
                         ResumeEduProgramQueueThread();
 
@@ -130,9 +132,10 @@ private:
                         }
                         // break;
 
-                        auto statusHistoryEntry =
-                            FindStatusAndHistoryEntry(status.programId, status.queueId);
-                        statusHistoryEntry.status = ProgramStatus::resultFileTransfered;
+                        auto eduProgramStatusHistoryEntry =
+                            FindEduProgramStatusHistoryEntry(status.programId, status.queueId);
+                        eduProgramStatusHistoryEntry.status =
+                            EduProgramStatus::resultFileTransfered;
 
                         break;
                     }

--- a/Sts1CobcSw/EduListenerThread.cpp
+++ b/Sts1CobcSw/EduListenerThread.cpp
@@ -2,6 +2,7 @@
 #include <Sts1CobcSw/EduListenerThread.hpp>
 #include <Sts1CobcSw/EduProgramQueue.hpp>
 #include <Sts1CobcSw/EduProgramQueueThread.hpp>
+#include <Sts1CobcSw/EduProgramStatusHistory.hpp>
 #include <Sts1CobcSw/Hal/IoNames.hpp>
 #include <Sts1CobcSw/Hal/PinNames.hpp>
 #include <Sts1CobcSw/Periphery/Edu.hpp>
@@ -23,10 +24,6 @@ constexpr auto timeLoopPeriod = 1 * RODOS::SECONDS;
 
 // Can't use auto here since GCC throws an error about conflicting declarations otherwise :(
 hal::GpioPin eduUpdateGpioPin(hal::eduUpdatePin);
-
-
-auto FindStatusAndHistoryEntry(std::uint16_t programId, std::uint16_t queueId)
-    -> StatusHistoryEntry;
 
 
 class EduListenerThread : public StaticThread<>
@@ -151,19 +148,4 @@ private:
         }
     }
 } eduListenerThread;
-
-
-auto FindStatusAndHistoryEntry(std::uint16_t programId, std::uint16_t queueId) -> StatusHistoryEntry
-{
-    auto counter = 0;
-    auto statusHistoryEntry = StatusHistoryEntry{};
-    do
-    {
-        statusHistory.get(statusHistoryEntry);
-        // RODOS::PRINTF("%d,%d vs %d,%d\n", statusHistoryEntry.programId,
-        // statusHistoryEntry.queueId, programId, queueId);
-    } while(statusHistoryEntry.queueId != queueId or statusHistoryEntry.programId != programId);
-
-    return statusHistoryEntry;
-}
 }

--- a/Sts1CobcSw/EduProgramQueue.cpp
+++ b/Sts1CobcSw/EduProgramQueue.cpp
@@ -7,5 +7,4 @@ namespace sts1cobcsw
 {
 std::uint16_t queueIndex = 0U;
 etl::vector<EduQueueEntry, eduProgramQueueSize> eduProgramQueue{};
-RODOS::RingBuffer<StatusHistoryEntry, statusHistorySize> statusHistory{};
 }

--- a/Sts1CobcSw/EduProgramQueue.hpp
+++ b/Sts1CobcSw/EduProgramQueue.hpp
@@ -58,35 +58,8 @@ inline auto DeserializeFrom(void const * source, EduQueueEntry * data) -> void c
 }
 
 
-// TODO: Move the status and history related stuff to its own StatusAndHistory.hpp
-enum class ProgramStatus : uint8_t
-{
-    programRunning,
-    programCouldNotBeStarted,
-    programExecutionFailed,
-    programExecutionSucceeded,
-    resultFileTransfered,
-    resultFileSentToRf,
-    ackFromGround,
-    resultFileDeleted
-};
-
-
-struct StatusHistoryEntry
-{
-    ts::uint16_t programId = 0_u16;
-    ts::uint16_t queueId = 0_u16;
-    ProgramStatus status = ProgramStatus::programRunning;
-};
-
 inline constexpr auto eduProgramQueueSize = 20;
-// TODO: Think about the name. Maybe something like program/queueStatusAndHistory is better?
-inline constexpr auto statusHistorySize = 20;
 
-// TODO: Why is this defined in EduProgramQueueThread.cpp and not EduProgramQueue.cpp?
 extern uint16_t queueIndex;
 extern etl::vector<EduQueueEntry, eduProgramQueueSize> eduProgramQueue;
-// TODO: Maybe move that to its own file? Together with the definition of StatusHistoryEntry of
-// course.
-extern RODOS::RingBuffer<StatusHistoryEntry, statusHistorySize> statusHistory;
 }

--- a/Sts1CobcSw/EduProgramQueueThread.cpp
+++ b/Sts1CobcSw/EduProgramQueueThread.cpp
@@ -1,6 +1,7 @@
 #include <Sts1CobcSw/EduCommunicationErrorThread.hpp>
 #include <Sts1CobcSw/EduProgramQueue.hpp>
 #include <Sts1CobcSw/EduProgramQueueThread.hpp>
+#include <Sts1CobcSw/EduProgramStatusHistory.hpp>
 #include <Sts1CobcSw/Periphery/EduEnums.hpp>
 #include <Sts1CobcSw/Periphery/EduStructs.hpp>
 #include <Sts1CobcSw/ThreadPriorities.hpp>

--- a/Sts1CobcSw/EduProgramQueueThread.cpp
+++ b/Sts1CobcSw/EduProgramQueueThread.cpp
@@ -147,11 +147,11 @@ private:
             }
             else
             {
-                auto statusHistoryEntry =
-                    StatusHistoryEntry{.programId = programId,
-                                       .queueId = queueId,
-                                       .status = ProgramStatus::programRunning};
-                statusHistory.put(statusHistoryEntry);
+                auto eduProgramStatusHistoryEntry =
+                    EduProgramStatusHistoryEntry{.programId = programId,
+                                                 .queueId = queueId,
+                                                 .status = EduProgramStatus::programRunning};
+                eduProgramStatusHistory.put(eduProgramStatusHistoryEntry);
 
                 // Suspend Self for execution time
                 auto const executionTime = timeout.get() + eduCommunicationDelay;

--- a/Sts1CobcSw/EduProgramQueueThread.cpp
+++ b/Sts1CobcSw/EduProgramQueueThread.cpp
@@ -147,11 +147,10 @@ private:
             }
             else
             {
-                auto eduProgramStatusHistoryEntry =
+                eduProgramStatusHistory.put(
                     EduProgramStatusHistoryEntry{.programId = programId,
                                                  .queueId = queueId,
-                                                 .status = EduProgramStatus::programRunning};
-                eduProgramStatusHistory.put(eduProgramStatusHistoryEntry);
+                                                 .status = EduProgramStatus::programRunning});
 
                 // Suspend Self for execution time
                 auto const executionTime = timeout.get() + eduCommunicationDelay;

--- a/Sts1CobcSw/EduProgramStatusHistory.cpp
+++ b/Sts1CobcSw/EduProgramStatusHistory.cpp
@@ -6,17 +6,18 @@
 namespace sts1cobcsw
 {
 
-auto FindStatusAndHistoryEntry(std::uint16_t programId, std::uint16_t queueId) -> StatusHistoryEntry
+auto FindEduProgramStatusHistoryEntry(std::uint16_t programId, std::uint16_t queueId)
+    -> EduProgramStatusHistoryEntry
 {
-    auto counter = 0;
-    auto statusHistoryEntry = StatusHistoryEntry{};
+    auto eduProgramStatusHistoryEntry = EduProgramStatusHistoryEntry{};
     do
     {
-        statusHistory.get(statusHistoryEntry);
-        // RODOS::PRINTF("%d,%d vs %d,%d\n", statusHistoryEntry.programId,
-        // statusHistoryEntry.queueId, programId, queueId);
-    } while(statusHistoryEntry.queueId != queueId or statusHistoryEntry.programId != programId);
+        eduProgramStatusHistory.get(eduProgramStatusHistoryEntry);
+        // RODOS::PRINTF("%d,%d vs %d,%d\n", eduProgramStatusHistoryEntry.programId,
+        // eduProgramStatusHistoryEntry.queueId, programId, queueId);
+    } while(eduProgramStatusHistoryEntry.queueId != queueId
+            or eduProgramStatusHistoryEntry.programId != programId);
 
-    return statusHistoryEntry;
+    return eduProgramStatusHistoryEntry;
 }
 }

--- a/Sts1CobcSw/EduProgramStatusHistory.cpp
+++ b/Sts1CobcSw/EduProgramStatusHistory.cpp
@@ -1,0 +1,22 @@
+#include <Sts1CobcSw/EduProgramStatusHistory.hpp>
+
+#include <rodos.h>
+
+
+namespace sts1cobcsw
+{
+
+auto FindStatusAndHistoryEntry(std::uint16_t programId, std::uint16_t queueId) -> StatusHistoryEntry
+{
+    auto counter = 0;
+    auto statusHistoryEntry = StatusHistoryEntry{};
+    do
+    {
+        statusHistory.get(statusHistoryEntry);
+        // RODOS::PRINTF("%d,%d vs %d,%d\n", statusHistoryEntry.programId,
+        // statusHistoryEntry.queueId, programId, queueId);
+    } while(statusHistoryEntry.queueId != queueId or statusHistoryEntry.programId != programId);
+
+    return statusHistoryEntry;
+}
+}

--- a/Sts1CobcSw/EduProgramStatusHistory.cpp
+++ b/Sts1CobcSw/EduProgramStatusHistory.cpp
@@ -5,6 +5,9 @@
 
 namespace sts1cobcsw
 {
+RODOS::RingBuffer<EduProgramStatusHistoryEntry, eduProgramStatusHistorySize>
+    eduProgramStatusHistory;
+
 
 auto FindEduProgramStatusHistoryEntry(std::uint16_t programId, std::uint16_t queueId)
     -> EduProgramStatusHistoryEntry

--- a/Sts1CobcSw/EduProgramStatusHistory.hpp
+++ b/Sts1CobcSw/EduProgramStatusHistory.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+
+#include <ringbuffer.h>
+
+#include <type_safe/types.hpp>
+
+namespace sts1cobcsw
+{
+namespace ts = type_safe;
+using ts::operator""_u16;
+
+enum class ProgramStatus : uint8_t
+{
+    programRunning,
+    programCouldNotBeStarted,
+    programExecutionFailed,
+    programExecutionSucceeded,
+    resultFileTransfered,
+    resultFileSentToRf,
+    ackFromGround,
+    resultFileDeleted
+};
+
+
+struct StatusHistoryEntry
+{
+    ts::uint16_t programId = 0_u16;
+    ts::uint16_t queueId = 0_u16;
+    ProgramStatus status = ProgramStatus::programRunning;
+};
+
+// TODO: Think about the name. Maybe something like program/queueStatusAndHistory is better?
+inline constexpr auto statusHistorySize = 20;
+
+RODOS::RingBuffer<StatusHistoryEntry, statusHistorySize> statusHistory;
+
+auto FindStatusAndHistoryEntry(std::uint16_t programId, std::uint16_t queueId)
+    -> StatusHistoryEntry;
+}

--- a/Sts1CobcSw/EduProgramStatusHistory.hpp
+++ b/Sts1CobcSw/EduProgramStatusHistory.hpp
@@ -6,10 +6,12 @@
 
 #include <cstdint>
 
+
 namespace sts1cobcsw
 {
 namespace ts = type_safe;
 using ts::operator""_u16;
+
 
 enum class EduProgramStatus : uint8_t
 {
@@ -31,10 +33,11 @@ struct EduProgramStatusHistoryEntry
     EduProgramStatus status = EduProgramStatus::programRunning;
 };
 
-// TODO: Think about the name. Maybe something like program/queueStatusAndHistory is better?
+
 inline constexpr auto eduProgramStatusHistorySize = 20;
 extern RODOS::RingBuffer<EduProgramStatusHistoryEntry, eduProgramStatusHistorySize>
     eduProgramStatusHistory;
+
 
 auto FindEduProgramStatusHistoryEntry(std::uint16_t programId, std::uint16_t queueId)
     -> EduProgramStatusHistoryEntry;

--- a/Sts1CobcSw/EduProgramStatusHistory.hpp
+++ b/Sts1CobcSw/EduProgramStatusHistory.hpp
@@ -33,8 +33,7 @@ struct EduProgramStatusHistoryEntry
 
 // TODO: Think about the name. Maybe something like program/queueStatusAndHistory is better?
 inline constexpr auto eduProgramStatusHistorySize = 20;
-
-RODOS::RingBuffer<EduProgramStatusHistoryEntry, eduProgramStatusHistorySize>
+extern RODOS::RingBuffer<EduProgramStatusHistoryEntry, eduProgramStatusHistorySize>
     eduProgramStatusHistory;
 
 auto FindEduProgramStatusHistoryEntry(std::uint16_t programId, std::uint16_t queueId)

--- a/Sts1CobcSw/EduProgramStatusHistory.hpp
+++ b/Sts1CobcSw/EduProgramStatusHistory.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-#include <cstdint>
+#include <type_safe/types.hpp>
 
 #include <ringbuffer.h>
 
-#include <type_safe/types.hpp>
+#include <cstdint>
 
 namespace sts1cobcsw
 {
 namespace ts = type_safe;
 using ts::operator""_u16;
 
-enum class ProgramStatus : uint8_t
+enum class EduProgramStatus : uint8_t
 {
     programRunning,
     programCouldNotBeStarted,
@@ -24,18 +24,19 @@ enum class ProgramStatus : uint8_t
 };
 
 
-struct StatusHistoryEntry
+struct EduProgramStatusHistoryEntry
 {
     ts::uint16_t programId = 0_u16;
     ts::uint16_t queueId = 0_u16;
-    ProgramStatus status = ProgramStatus::programRunning;
+    EduProgramStatus status = EduProgramStatus::programRunning;
 };
 
 // TODO: Think about the name. Maybe something like program/queueStatusAndHistory is better?
-inline constexpr auto statusHistorySize = 20;
+inline constexpr auto eduProgramStatusHistorySize = 20;
 
-RODOS::RingBuffer<StatusHistoryEntry, statusHistorySize> statusHistory;
+RODOS::RingBuffer<EduProgramStatusHistoryEntry, eduProgramStatusHistorySize>
+    eduProgramStatusHistory;
 
-auto FindStatusAndHistoryEntry(std::uint16_t programId, std::uint16_t queueId)
-    -> StatusHistoryEntry;
+auto FindEduProgramStatusHistoryEntry(std::uint16_t programId, std::uint16_t queueId)
+    -> EduProgramStatusHistoryEntry;
 }

--- a/Tests/GoldenTests/CMakeLists.txt
+++ b/Tests/GoldenTests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_golden_test(
     SOURCE
     "${Sts1CobcSw}/TopicsAndSubscribers.cpp"
     "${Sts1CobcSw}/EduProgramQueue.cpp"
+    "${Sts1CobcSw}/EduProgramStatusHistory.cpp"
     LIB
     rodos::rodos
     Sts1CobcSw_Periphery


### PR DESCRIPTION
Moves related code from `EduListenerThread` and `EduProgramQueue` into `EduProgramStatusHistory`, which fixes #51 and closes #50, which was left open by accident.
This is a redo of #104, as this way of deconflicting with #97 is easier.