### PR TITLE
Make Cppcheck quiet when no error is detected

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -33,7 +33,7 @@
       "name": "cppcheck",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_CXX_CPPCHECK": "cppcheck;--inline-suppr"
+        "CMAKE_CXX_CPPCHECK": "cppcheck;--inline-suppr;--quiet;--suppress=cppcheckError"
       }
     },
     {


### PR DESCRIPTION
### Description

Make Cppcheck more quiet by:

- Using the `--quiet` flag, which “only prints something when there is an error”.
- Using the `--suppress` flag to suppress Cppcheck internal error `cppCheckError` (which we get when Cppcheck is trying to parse `0_u64`).
