### PR TITLE
Refactor command parsing

### DIFF
--- a/Sts1CobcSw/CMakeLists.txt
+++ b/Sts1CobcSw/CMakeLists.txt
@@ -14,15 +14,16 @@ target_link_libraries(Sts1CobcSw_Dummy PUBLIC etl::etl)
 target_sources(Sts1CobcSw_HelloDummy PRIVATE HelloDummy.cpp)
 target_link_libraries(Sts1CobcSw_HelloDummy PRIVATE Sts1CobcSw_Dummy rodos::rodos)
 
-#target_sources(Sts1CobcSw_Heartbeat PRIVATE EduHeartbeatThread.cpp TopicsAndSubscribers.cpp)
-#target_link_libraries(Sts1CobcSw_Heartbeat PRIVATE etl::etl rodos::rodos type_safe Sts1CobcSw_Hal Sts1CobcSw_Utility Sts1CobcSw_Periphery)
-
+# target_sources(Sts1CobcSw_Heartbeat PRIVATE EduHeartbeatThread.cpp TopicsAndSubscribers.cpp)
+# target_link_libraries(Sts1CobcSw_Heartbeat PRIVATE etl::etl rodos::rodos type_safe Sts1CobcSw_Hal
+# Sts1CobcSw_Utility Sts1CobcSw_Periphery)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Generic)
-    #if(FALSE)
+    # if(FALSE)
     target_sources(
         Sts1CobcSw_CobcSw
-        PRIVATE CommandParserThread.cpp
+        PRIVATE CommandParser.cpp
+                CommandParserThread.cpp
                 EduHeartbeatThread.cpp
                 EduPowerManagementThread.cpp
                 EduProgramQueue.cpp

--- a/Sts1CobcSw/CommandParser.cpp
+++ b/Sts1CobcSw/CommandParser.cpp
@@ -1,16 +1,11 @@
 #include <Sts1CobcSw/CommandParser.hpp>
 #include <Sts1CobcSw/EduProgramQueue.hpp>
 #include <Sts1CobcSw/EduProgramQueueThread.hpp>
-#include <Sts1CobcSw/Serial/Byte.hpp>
-#include <Sts1CobcSw/Serial/Serial.hpp>
 #include <Sts1CobcSw/Utility/Time.hpp>
-
-#include <type_safe/types.hpp>
 
 
 namespace sts1cobcsw
 {
-
 using sts1cobcsw::serial::Byte;
 using sts1cobcsw::serial::Deserialize;
 using sts1cobcsw::serial::SerialBuffer;
@@ -19,13 +14,8 @@ using sts1cobcsw::serial::serialSize;
 
 auto DispatchCommand(etl::vector<Byte, commandSize> const & command) -> void
 {
-    auto commandHeader = std::span<const Byte, serial::serialSize<GsCommandHeader>>(
-        command.data(), serialSize<GsCommandHeader>);
-    auto commandData =
-        std::span<const Byte>(command.data() + serialSize<GsCommandHeader>, dataSize);
-
-
-    auto gsCommandHeader = serial::Deserialize<GsCommandHeader>(commandHeader);
+    auto gsCommandHeader =
+        Deserialize<GsCommandHeader>(std::span(command).first<serialSize<GsCommandHeader>>());
 
     // TODO: Debug print, to be removed
     RODOS::PRINTF("Header start character : %c\n", gsCommandHeader.startCharacter);
@@ -54,7 +44,7 @@ auto DispatchCommand(etl::vector<Byte, commandSize> const & command) -> void
             }
             case CommandId::buildQueue:
             {
-                BuildEduQueue(commandData);
+                BuildEduQueue(std::span(command).subspan<serialSize<GsCommandHeader>>());
                 return;
             }
             default:
@@ -68,25 +58,27 @@ auto DispatchCommand(etl::vector<Byte, commandSize> const & command) -> void
     RODOS::PRINTF("Not implemented yet.\n");
 }
 
-auto BuildEduQueue(std::span<const Byte> commandData) -> void
+
+auto BuildEduQueue(std::span<Byte const> commandData) -> void
 {
     RODOS::PRINTF("Entering build queue command parsing\n");
 
     eduProgramQueue.clear();
-
-    ParseAndAddQueueEntrie(commandData);
+    ParseAndAddQueueEntries(commandData);
     queueIndex = 0U;
+
     RODOS::PRINTF("Queue index reset. Current size of EDU program queue is %d.\n",
                   static_cast<int>(eduProgramQueue.size()));
 
     ResumeEduProgramQueueThread();
 }
 
+
 //! @brief Parse and add queue entries from a given span of bytes
 //!
 //! This function takes a span of bytes containing serialized EDU queue entries, deserializes them,
 //! and adds them to the global EDU program queue.
-auto ParseAndAddQueueEntrie(std::span<const Byte> & queueEntries) -> void
+auto ParseAndAddQueueEntries(std::span<Byte const> queueEntries) -> void
 {
     RODOS::PRINTF("Printing and parsing\n");
 
@@ -97,8 +89,8 @@ auto ParseAndAddQueueEntrie(std::span<const Byte> & queueEntries) -> void
     for(auto & entry : eduProgramQueue)
     {
         // TODO: is this the way serial library is intended to be used (lack of SerialBuffer)
-        auto offset = index * serial::serialSize<EduQueueEntry>;
-        auto entryBuffer = std::span<const Byte, serial::serialSize<EduQueueEntry>>(
+        auto offset = index * serialSize<EduQueueEntry>;
+        auto entryBuffer = std::span<const Byte, serialSize<EduQueueEntry>>(
             queueEntries.data() + offset, serialSize<EduQueueEntry>);
         // entry = serial::DeserializeConst<EduQueueEntry>(entryBuffer);
         entry = Deserialize<EduQueueEntry>(entryBuffer);
@@ -108,7 +100,7 @@ auto ParseAndAddQueueEntrie(std::span<const Byte> & queueEntries) -> void
         RODOS::PRINTF("Start Time   : %d\n", entry.startTime.get());
         RODOS::PRINTF("Timeout      : %d\n", entry.timeout.get());
 
-        // Should never be superior or equal to nQueueEntries
+        // Should never be greater or equal to nQueueEntries
         index++;
     }
 }

--- a/Sts1CobcSw/CommandParser.cpp
+++ b/Sts1CobcSw/CommandParser.cpp
@@ -1,0 +1,117 @@
+#include <Sts1CobcSw/CommandParser.hpp>
+#include <Sts1CobcSw/EduProgramQueue.hpp>
+#include <Sts1CobcSw/EduProgramQueueThread.hpp>
+#include <Sts1CobcSw/Serial/Byte.hpp>
+#include <Sts1CobcSw/Serial/Serial.hpp>
+#include <Sts1CobcSw/Utility/Time.hpp>
+
+#include <type_safe/types.hpp>
+
+
+namespace sts1cobcsw
+{
+
+using sts1cobcsw::serial::Byte;
+using sts1cobcsw::serial::Deserialize;
+using sts1cobcsw::serial::SerialBuffer;
+using sts1cobcsw::serial::serialSize;
+
+// TODO: Calculate this correctly.
+constexpr std::size_t dataSize = 22;
+
+auto DispatchCommand(etl::vector<Byte, commandSize> const & command) -> void
+{
+    auto commandHeader = std::span<const Byte, serial::serialSize<GsCommandHeader>>(
+        command.data(), serialSize<GsCommandHeader>);
+    auto commandData =
+        std::span<const Byte>(command.data() + serialSize<GsCommandHeader>, dataSize);
+
+
+    auto gsCommandHeader = serial::Deserialize<GsCommandHeader>(commandHeader);
+
+    // TODO: Debug print, to be removed
+    RODOS::PRINTF("Header start character : %c\n", gsCommandHeader.startCharacter);
+    RODOS::PRINTF("Header commandID       : %d\n", gsCommandHeader.commandId);
+    RODOS::PRINTF("Header utc             : %d\n", gsCommandHeader.utc);
+    RODOS::PRINTF("Header length          : %d\n", gsCommandHeader.length);
+
+    // TODO: Move this somewhere else
+    RODOS::sysTime.setUTC(utility::UnixToRodosTime(gsCommandHeader.utc));
+    utility::PrintFormattedSystemUtc();
+
+    auto targetIsCobc = true;
+    if(targetIsCobc)
+    {
+        switch(gsCommandHeader.commandId)
+        {
+            case CommandId::turnEduOn:
+            {
+                edu.TurnOn();
+                return;
+            }
+            case CommandId::turnEduOff:
+            {
+                edu.TurnOff();
+                return;
+            }
+            case CommandId::buildQueue:
+            {
+                BuildEduQueue(commandData);
+                return;
+            }
+            default:
+            {
+                RODOS::PRINTF("*Error, invalid command*\n");
+                return;
+            }
+        }
+    }
+
+    RODOS::PRINTF("Not implemented yet.\n");
+}
+
+auto BuildEduQueue(std::span<const Byte> commandData) -> void
+{
+    RODOS::PRINTF("Entering build queue command parsing\n");
+
+    eduProgramQueue.clear();
+
+    ParseAndAddQueueEntrie(commandData);
+    queueIndex = 0U;
+    RODOS::PRINTF("Queue index reset. Current size of EDU program queue is %d.\n",
+                  static_cast<int>(eduProgramQueue.size()));
+
+    ResumeEduProgramQueueThread();
+}
+
+//! @brief Parse and add queue entries from a given span of bytes
+//!
+//! This function takes a span of bytes containing serialized EDU queue entries, deserializes them,
+//! and adds them to the global EDU program queue.
+auto ParseAndAddQueueEntrie(std::span<const Byte> & queueEntries) -> void
+{
+    RODOS::PRINTF("Printing and parsing\n");
+
+    auto const nQueueEntries = queueEntries.size() / queueEntrySize;
+    eduProgramQueue.resize(nQueueEntries);
+
+    std::size_t index = 0;
+    for(auto & entry : eduProgramQueue)
+    {
+        // TODO: is this the way serial library is intended to be used (lack of SerialBuffer)
+        auto offset = index * serial::serialSize<EduQueueEntry>;
+        auto entryBuffer = std::span<const Byte, serial::serialSize<EduQueueEntry>>(
+            queueEntries.data() + offset, serialSize<EduQueueEntry>);
+        // entry = serial::DeserializeConst<EduQueueEntry>(entryBuffer);
+        entry = Deserialize<EduQueueEntry>(entryBuffer);
+
+        RODOS::PRINTF("Prog ID      : %d\n", static_cast<int>(entry.programId.get()));
+        RODOS::PRINTF("Queue ID     : %d\n", static_cast<int>(entry.queueId.get()));
+        RODOS::PRINTF("Start Time   : %d\n", static_cast<int>(entry.startTime.get()));
+        RODOS::PRINTF("Timeout      : %d\n", static_cast<int>(entry.timeout.get()));
+
+        // Should never be superior or equal to nQueueEntries
+        index++;
+    }
+}
+}

--- a/Sts1CobcSw/CommandParser.cpp
+++ b/Sts1CobcSw/CommandParser.cpp
@@ -90,7 +90,7 @@ auto ParseAndAddQueueEntrie(std::span<const Byte> & queueEntries) -> void
 {
     RODOS::PRINTF("Printing and parsing\n");
 
-    auto const nQueueEntries = queueEntries.size() / queueEntrySize;
+    auto const nQueueEntries = queueEntries.size() / serialSize<EduQueueEntry>;
     eduProgramQueue.resize(nQueueEntries);
 
     std::size_t index = 0;

--- a/Sts1CobcSw/CommandParser.cpp
+++ b/Sts1CobcSw/CommandParser.cpp
@@ -16,8 +16,6 @@ using sts1cobcsw::serial::Deserialize;
 using sts1cobcsw::serial::SerialBuffer;
 using sts1cobcsw::serial::serialSize;
 
-// TODO: Calculate this correctly.
-constexpr std::size_t dataSize = 22;
 
 auto DispatchCommand(etl::vector<Byte, commandSize> const & command) -> void
 {
@@ -105,10 +103,10 @@ auto ParseAndAddQueueEntrie(std::span<const Byte> & queueEntries) -> void
         // entry = serial::DeserializeConst<EduQueueEntry>(entryBuffer);
         entry = Deserialize<EduQueueEntry>(entryBuffer);
 
-        RODOS::PRINTF("Prog ID      : %d\n", static_cast<int>(entry.programId.get()));
-        RODOS::PRINTF("Queue ID     : %d\n", static_cast<int>(entry.queueId.get()));
-        RODOS::PRINTF("Start Time   : %d\n", static_cast<int>(entry.startTime.get()));
-        RODOS::PRINTF("Timeout      : %d\n", static_cast<int>(entry.timeout.get()));
+        RODOS::PRINTF("Prog ID      : %d\n", entry.programId.get());
+        RODOS::PRINTF("Queue ID     : %d\n", entry.queueId.get());
+        RODOS::PRINTF("Start Time   : %d\n", entry.startTime.get());
+        RODOS::PRINTF("Timeout      : %d\n", entry.timeout.get());
 
         // Should never be superior or equal to nQueueEntries
         index++;

--- a/Sts1CobcSw/CommandParser.hpp
+++ b/Sts1CobcSw/CommandParser.hpp
@@ -49,12 +49,9 @@ inline auto DeserializeFrom(void const * source, GsCommandHeader * data) -> void
     return source;
 }
 
-constexpr std::size_t commandSize = 30;
-constexpr std::size_t dataSize = commandSize - serial::serialSize<GsCommandHeader>;
-// TODO: Use serialSize<EduQueueEntry> instead
-constexpr std::size_t queueEntrySize =
-    sizeof(EduQueueEntry::programId) + sizeof(EduQueueEntry::queueId)
-    + sizeof(EduQueueEntry::startTime) + sizeof(EduQueueEntry::timeout);
+
+inline constexpr std::size_t commandSize = 30;
+inline constexpr std::size_t dataSize = commandSize - serial::serialSize<GsCommandHeader>;
 
 
 auto DispatchCommand(etl::vector<Byte, commandSize> const & command) -> void;

--- a/Sts1CobcSw/CommandParser.hpp
+++ b/Sts1CobcSw/CommandParser.hpp
@@ -29,16 +29,6 @@ struct GsCommandHeader
 };
 
 
-constexpr std::size_t commandSize = 30;
-constexpr std::size_t queueEntrySize =
-    sizeof(EduQueueEntry::programId) + sizeof(EduQueueEntry::queueId)
-    + sizeof(EduQueueEntry::startTime) + sizeof(EduQueueEntry::timeout);
-
-auto DispatchCommand(etl::vector<Byte, commandSize> const & command) -> void;
-auto ParseAndAddQueueEntrie(std::span<const Byte> & queueEntries) -> void;
-auto BuildEduQueue(std::span<const Byte> commandData) -> void;
-
-
 namespace serial
 {
 template<>
@@ -58,4 +48,15 @@ inline auto DeserializeFrom(void const * source, GsCommandHeader * data) -> void
     source = DeserializeFrom(source, &(data->length));
     return source;
 }
+
+constexpr std::size_t commandSize = 30;
+constexpr std::size_t dataSize = commandSize - serial::serialSize<GsCommandHeader>;
+constexpr std::size_t queueEntrySize =
+    sizeof(EduQueueEntry::programId) + sizeof(EduQueueEntry::queueId)
+    + sizeof(EduQueueEntry::startTime) + sizeof(EduQueueEntry::timeout);
+
+
+auto DispatchCommand(etl::vector<Byte, commandSize> const & command) -> void;
+auto ParseAndAddQueueEntrie(std::span<const Byte> & queueEntries) -> void;
+auto BuildEduQueue(std::span<const Byte> commandData) -> void;
 }

--- a/Sts1CobcSw/CommandParser.hpp
+++ b/Sts1CobcSw/CommandParser.hpp
@@ -1,7 +1,10 @@
+#include <Sts1CobcSw/EduProgramQueue.hpp>
 #include <Sts1CobcSw/Serial/Byte.hpp>
 #include <Sts1CobcSw/Serial/Serial.hpp>
 
 #include <type_safe/types.hpp>
+
+#include <etl/vector.h>
 
 
 namespace sts1cobcsw
@@ -24,6 +27,16 @@ struct GsCommandHeader
     std::int8_t commandId;
     std::int16_t length;
 };
+
+
+constexpr std::size_t commandSize = 30;
+constexpr std::size_t queueEntrySize =
+    sizeof(EduQueueEntry::programId) + sizeof(EduQueueEntry::queueId)
+    + sizeof(EduQueueEntry::startTime) + sizeof(EduQueueEntry::timeout);
+
+auto DispatchCommand(etl::vector<Byte, commandSize> const & command) -> void;
+auto ParseAndAddQueueEntrie(std::span<const Byte> & queueEntries) -> void;
+auto BuildEduQueue(std::span<const Byte> commandData) -> void;
 
 
 namespace serial

--- a/Sts1CobcSw/CommandParser.hpp
+++ b/Sts1CobcSw/CommandParser.hpp
@@ -1,8 +1,5 @@
-#include <Sts1CobcSw/EduProgramQueue.hpp>
 #include <Sts1CobcSw/Serial/Byte.hpp>
 #include <Sts1CobcSw/Serial/Serial.hpp>
-
-#include <type_safe/types.hpp>
 
 #include <etl/vector.h>
 
@@ -19,6 +16,7 @@ enum CommandId : char
     turnEduOff = '2',
     buildQueue = '4',
 };
+
 
 struct GsCommandHeader
 {
@@ -39,7 +37,15 @@ inline constexpr std::size_t serialSize<GsCommandHeader> =
                     decltype(GsCommandHeader::length)>;
 }
 
+inline constexpr std::size_t commandSize = 30;
 
+
+auto DispatchCommand(etl::vector<Byte, commandSize> const & command) -> void;
+auto ParseAndAddQueueEntries(std::span<Byte const> queueEntries) -> void;
+auto BuildEduQueue(std::span<Byte const> commandData) -> void;
+
+
+// TODO: Turn into noninline function
 inline auto DeserializeFrom(void const * source, GsCommandHeader * data) -> void const *
 {
     source = DeserializeFrom(source, &(data->startCharacter));
@@ -48,13 +54,4 @@ inline auto DeserializeFrom(void const * source, GsCommandHeader * data) -> void
     source = DeserializeFrom(source, &(data->length));
     return source;
 }
-
-
-inline constexpr std::size_t commandSize = 30;
-inline constexpr std::size_t dataSize = commandSize - serial::serialSize<GsCommandHeader>;
-
-
-auto DispatchCommand(etl::vector<Byte, commandSize> const & command) -> void;
-auto ParseAndAddQueueEntrie(std::span<const Byte> & queueEntries) -> void;
-auto BuildEduQueue(std::span<const Byte> commandData) -> void;
 }

--- a/Sts1CobcSw/CommandParser.hpp
+++ b/Sts1CobcSw/CommandParser.hpp
@@ -51,6 +51,7 @@ inline auto DeserializeFrom(void const * source, GsCommandHeader * data) -> void
 
 constexpr std::size_t commandSize = 30;
 constexpr std::size_t dataSize = commandSize - serial::serialSize<GsCommandHeader>;
+// TODO: Use serialSize<EduQueueEntry> instead
 constexpr std::size_t queueEntrySize =
     sizeof(EduQueueEntry::programId) + sizeof(EduQueueEntry::queueId)
     + sizeof(EduQueueEntry::startTime) + sizeof(EduQueueEntry::timeout);

--- a/Sts1CobcSw/CommandParserThread.cpp
+++ b/Sts1CobcSw/CommandParserThread.cpp
@@ -36,7 +36,6 @@ using sts1cobcsw::serial::SerialBuffer;
 
 // TODO: Get a better estimation for the required stack size. We only have 128 kB of RAM.
 constexpr auto stackSize = 4'000U;
-constexpr std::size_t commandSize = 30;
 // TODO: Use serialSize<EduQueueEntry> instead
 constexpr std::size_t queueEntrySize =
     sizeof(EduQueueEntry::programId) + sizeof(EduQueueEntry::queueId)
@@ -64,9 +63,8 @@ private:
     {
         constexpr auto startCharacter = '$';
 
-        // TODO: The command is not a string. Turn this into an array of bytes, or if different
-        // commands have different size, use an etl::vector<Byte>
-        auto command = etl::string<commandSize>();
+        // TODO: The command is not a string.
+        auto command = etl::vector<Byte, commandSize>();
         ts::bool_t startWasDetected = false;
 
         while(true)
@@ -83,11 +81,11 @@ private:
                 {
                     startWasDetected = true;
                     command.clear();
-                    command += startCharacter;
+                    command.push_back(static_cast<Byte>(startCharacter));
                 }
                 else if(startWasDetected)
                 {
-                    command += readCharacter;
+                    command.push_back(static_cast<Byte>(startCharacter));
                     // Every command has the same size
                     if(command.full())
                     {
@@ -100,105 +98,4 @@ private:
         }
     }
 } commandParserThread;
-
-
-auto DispatchCommand(etl::string<commandSize> const & command) -> void
-{
-    auto buffer = std::array<std::byte, serial::serialSize<GsCommandHeader>>();
-    std::transform(
-        std::begin(command), std::end(command), std::begin(buffer), [](char c) { return Byte(c); });
-
-    // Debug print
-    for(auto & b : buffer)
-    {
-        RODOS::PRINTF("%d", std::to_integer<uint8_t>(b));
-    }
-
-    auto gsCommandHeader = serial::Deserialize<GsCommandHeader>(buffer);
-
-    // TODO: Why is this here? It has nothing to do with command dispatching
-    RODOS::sysTime.setUTC(utility::UnixToRodosTime(gsCommandHeader.utc));
-
-    utility::PrintFormattedSystemUtc();
-    RODOS::PRINTF("Command ID character : %c\n", gsCommandHeader.commandId);
-    RODOS::PRINTF("Length of data : %d\n", gsCommandHeader.length);
-
-    auto targetIsCobc = true;
-    if(targetIsCobc)
-    {
-        switch(gsCommandHeader.commandId)
-        {
-            case CommandId::turnEduOn:
-            {
-                edu.TurnOn();
-                return;
-            }
-            case CommandId::turnEduOff:
-            {
-                edu.TurnOff();
-                return;
-            }
-            case CommandId::buildQueue:
-            {
-                // TODO: This should be a function Build/BuildNew/Update/OverwriteEduQueue() or
-                // something like that
-                RODOS::PRINTF("Entering build queue command parsing\n");
-
-                auto const nbQueueEntries =
-                    gsCommandHeader.length / static_cast<int>(queueEntrySize);
-                RODOS::PRINTF("Number of queue entries : %d\n", nbQueueEntries);
-
-                // Erase all previous entries in the EDU program queue
-                eduProgramQueue.clear();
-
-                // FIXME: I think this is the wrong size because serialSize<T> != sizeof(T) in this
-                // case.
-                ParseAndAddQueueEntries(command.substr(
-                    sizeof(GsCommandHeader), static_cast<std::size_t>(gsCommandHeader.length)));
-
-                // Reset queue index
-                queueIndex = 0U;
-                RODOS::PRINTF("Queue index reset. Current size of EDU program queue is %d.\n",
-                              static_cast<int>(eduProgramQueue.size()));
-
-                ResumeEduProgramQueueThread();
-                return;
-            }
-            default:
-            {
-                RODOS::PRINTF("*Error, invalid command*\n");
-                return;
-            }
-        }
-    }
-}
-
-
-// TODO: Test all of this
-auto ParseAndAddQueueEntries(etl::string<commandSize> const & command) -> void
-{
-    auto const nQueueEntries = command.size() / queueEntrySize;
-    eduProgramQueue.resize(nQueueEntries);
-
-    auto buffer = SerialBuffer<EduQueueEntry>{};
-
-    std::size_t index = 0;
-    for(auto & entry : eduProgramQueue)
-    {
-        auto commandQueueEntrySubstring = command.substr(index * queueEntrySize, queueEntrySize);
-        std::transform(std::begin(commandQueueEntrySubstring),
-                       std::end(commandQueueEntrySubstring),
-                       std::begin(buffer),
-                       [](char c) { return Byte(c); });
-        entry = serial::Deserialize<EduQueueEntry>(buffer);
-
-        RODOS::PRINTF("Prog ID      : %d\n", static_cast<int>(entry.programId.get()));
-        RODOS::PRINTF("Queue ID     : %d\n", static_cast<int>(entry.queueId.get()));
-        RODOS::PRINTF("Start Time   : %d\n", static_cast<int>(entry.startTime.get()));
-        RODOS::PRINTF("Timeout      : %d\n", static_cast<int>(entry.timeout.get()));
-
-        // Should never be superior or equal to nQueueEntries
-        index++;
-    }
-}
 }

--- a/Sts1CobcSw/CommandParserThread.cpp
+++ b/Sts1CobcSw/CommandParserThread.cpp
@@ -36,15 +36,6 @@ using sts1cobcsw::serial::SerialBuffer;
 
 // TODO: Get a better estimation for the required stack size. We only have 128 kB of RAM.
 constexpr auto stackSize = 4'000U;
-// TODO: Use serialSize<EduQueueEntry> instead
-constexpr std::size_t queueEntrySize =
-    sizeof(EduQueueEntry::programId) + sizeof(EduQueueEntry::queueId)
-    + sizeof(EduQueueEntry::startTime) + sizeof(EduQueueEntry::timeout);
-
-
-auto DispatchCommand(etl::string<commandSize> const & command) -> void;
-auto ParseAndAddQueueEntries(etl::string<commandSize> const & command) -> void;
-
 
 class CommandParserThread : public RODOS::StaticThread<stackSize>
 {

--- a/Sts1CobcSw/CommandParserThread.cpp
+++ b/Sts1CobcSw/CommandParserThread.cpp
@@ -1,24 +1,12 @@
 #include <Sts1CobcSw/CommandParser.hpp>
-#include <Sts1CobcSw/EduProgramQueue.hpp>
-#include <Sts1CobcSw/EduProgramQueueThread.hpp>
-#include <Sts1CobcSw/Hal/Communication.hpp>
 #include <Sts1CobcSw/Serial/Byte.hpp>
-#include <Sts1CobcSw/Serial/Serial.hpp>
 #include <Sts1CobcSw/ThreadPriorities.hpp>
-#include <Sts1CobcSw/Utility/Crc32.hpp>
-#include <Sts1CobcSw/Utility/Time.hpp>
-
-#include <type_safe/index.hpp>
-#include <type_safe/narrow_cast.hpp>
-#include <type_safe/types.hpp>
 
 #include <rodos_no_using_namespace.h>
 
-#include <etl/string.h>
+#include <etl/vector.h>
 
-#include <cstdint>
-#include <cstring>
-#include <span>
+#include <cstddef>
 
 
 namespace RODOS
@@ -27,15 +15,16 @@ namespace RODOS
 extern HAL_UART uart_stdout;
 }
 
+
 namespace sts1cobcsw
 {
-namespace ts = type_safe;
-
 using sts1cobcsw::serial::Byte;
-using sts1cobcsw::serial::SerialBuffer;
+
 
 // TODO: Get a better estimation for the required stack size. We only have 128 kB of RAM.
 constexpr auto stackSize = 4'000U;
+constexpr auto startCharacter = '$';
+
 
 class CommandParserThread : public RODOS::StaticThread<stackSize>
 {
@@ -52,40 +41,38 @@ private:
 
     void run() override
     {
-        constexpr auto startCharacter = '$';
-
-        // TODO: The command is not a string.
         auto command = etl::vector<Byte, commandSize>();
-        ts::bool_t startWasDetected = false;
+        auto startWasDetected = false;
 
         while(true)
         {
             char readCharacter = 0;
             // TODO: This needs to be abstracted away because "IRL" we receive commands via the RF
             // module
-            ts::size_t nReadCharacters =
+            std::size_t nReadCharacters =
                 RODOS::uart_stdout.read(&readCharacter, sizeof(readCharacter));
-            if(nReadCharacters != 0U)
+            if(nReadCharacters == 0U)
             {
-                // RODOS::PRINTF("Read a character : %c\n", readCharacter);
-                if(readCharacter == startCharacter)
+                RODOS::uart_stdout.suspendUntilDataReady();
+                continue;
+            }
+
+            // RODOS::PRINTF("Read a character : %c\n", readCharacter);
+            if(readCharacter == startCharacter)
+            {
+                startWasDetected = true;
+                command.clear();
+            }
+            if(startWasDetected)
+            {
+                command.push_back(static_cast<Byte>(readCharacter));
+                // Every command has the same size
+                if(command.full())
                 {
-                    startWasDetected = true;
-                    command.clear();
-                    command.push_back(static_cast<Byte>(startCharacter));
-                }
-                else if(startWasDetected)
-                {
-                    command.push_back(static_cast<Byte>(startCharacter));
-                    // Every command has the same size
-                    if(command.full())
-                    {
-                        DispatchCommand(command);
-                        startWasDetected = false;
-                    }
+                    DispatchCommand(command);
+                    startWasDetected = false;
                 }
             }
-            RODOS::uart_stdout.suspendUntilDataReady();
         }
     }
 } commandParserThread;

--- a/Sts1CobcSw/EduProgramQueueThread.hpp
+++ b/Sts1CobcSw/EduProgramQueueThread.hpp
@@ -6,7 +6,7 @@
 
 namespace sts1cobcsw
 {
-// TODO: Maybe this should be in EduPowerManagement thread, or somewhere else entirely
+// TODO: This should be in Edu.hpp
 extern periphery::Edu edu;
 
 

--- a/Sts1CobcSw/Periphery/EduMock.cpp
+++ b/Sts1CobcSw/Periphery/EduMock.cpp
@@ -18,6 +18,11 @@ auto ResumeEduErrorCommunicationThread() -> void
     PrintFormattedSystemUtc();
 }
 
+auto ResumeEduProgramQueueThread() -> void
+{
+    PRINTF("Call to ResumeEduProgramQueueThread()\n");
+}
+
 
 // TODO: This file is not used at all right now. Think about the mocking later.
 namespace periphery

--- a/Sts1CobcSw/Serial/Serial.hpp
+++ b/Sts1CobcSw/Serial/Serial.hpp
@@ -132,7 +132,7 @@ template<typename T>
     requires std::is_same_v<T, type_safe::boolean>
 constexpr auto Deserialize(std::span<const Byte, serialSize<T>> source) -> T
 {
-    auto t = T{false};  // NOLINT(bugprone-argument-comment)
+    auto t = T{false};  // NOLINT(bugprone-argument-comment, readability-identifier-length)
     DeserializeFrom(source.data(), &t);
     return t;
 }

--- a/Sts1CobcSw/Serial/Serial.hpp
+++ b/Sts1CobcSw/Serial/Serial.hpp
@@ -113,7 +113,7 @@ constexpr auto Serialize(T const & data) -> SerialBuffer<T>
 template<std::default_initializable T>
 constexpr auto Deserialize(std::span<const Byte, serialSize<T>> source) -> T
 {
-    auto t = T{};
+    auto t = T{};  // NOLINT(readability-identifier-length)
     DeserializeFrom(source.data(), &t);
     return t;
 }
@@ -122,7 +122,7 @@ constexpr auto Deserialize(std::span<const Byte, serialSize<T>> source) -> T
 template<utility::TypeSafeInteger T>
 constexpr auto Deserialize(std::span<const Byte, serialSize<T>> source) -> T
 {
-    auto t = utility::TypeSafeZero<T>();
+    auto t = utility::TypeSafeZero<T>();  // NOLINT(readability-identifier-length)
     DeserializeFrom(source.data(), &t);
     return t;
 }

--- a/Sts1CobcSw/Serial/Serial.hpp
+++ b/Sts1CobcSw/Serial/Serial.hpp
@@ -113,7 +113,7 @@ constexpr auto Serialize(T const & data) -> SerialBuffer<T>
 template<std::default_initializable T>
 constexpr auto Deserialize(std::span<const Byte, serialSize<T>> source) -> T
 {
-    auto t = T{};  // NOLINT(readability-identifier-length)
+    auto t = T{};
     DeserializeFrom(source.data(), &t);
     return t;
 }
@@ -122,7 +122,7 @@ constexpr auto Deserialize(std::span<const Byte, serialSize<T>> source) -> T
 template<utility::TypeSafeInteger T>
 constexpr auto Deserialize(std::span<const Byte, serialSize<T>> source) -> T
 {
-    auto t = utility::TypeSafeZero<T>();  // NOLINT(readability-identifier-length)
+    auto t = utility::TypeSafeZero<T>();
     DeserializeFrom(source.data(), &t);
     return t;
 }
@@ -132,7 +132,7 @@ template<typename T>
     requires std::is_same_v<T, type_safe::boolean>
 constexpr auto Deserialize(std::span<const Byte, serialSize<T>> source) -> T
 {
-    auto t = T{false};  // NOLINT(bugprone-argument-comment, readability-identifier-length)
+    auto t = T{false};  // NOLINT(bugprone-argument-comment)
     DeserializeFrom(source.data(), &t);
     return t;
 }

--- a/Tests/GoldenTests/CMakeLists.txt
+++ b/Tests/GoldenTests/CMakeLists.txt
@@ -10,17 +10,18 @@ add_golden_test(
 )
 add_golden_test(TESTFILE "HelloDummy.test.cpp" LIB rodos::rodos Sts1CobcSw_Dummy)
 
-# Testing a "real" thread
 add_golden_test(
     TESTFILE
-    "${Sts1CobcSw}/EduProgramQueueThread.cpp"
+    "DispatchCommand.test.cpp"
     SOURCE
-    "${Sts1CobcSw}/TopicsAndSubscribers.cpp"
+    "${Sts1CobcSw}/CommandParser.cpp"
     "${Sts1CobcSw}/EduProgramQueue.cpp"
     LIB
     rodos::rodos
+    etl::etl
     Sts1CobcSw_Periphery
     Sts1CobcSw_Utility
+    Sts1CobcSw_Serial
 )
 
 add_custom_target(AllGoldenTests DEPENDS ${output_files})

--- a/Tests/GoldenTests/DispatchCommand.test.cpp
+++ b/Tests/GoldenTests/DispatchCommand.test.cpp
@@ -1,0 +1,91 @@
+#include <Sts1CobcSw/CommandParser.hpp>
+#include <Sts1CobcSw/Periphery/Edu.hpp>
+#include <Sts1CobcSw/Serial/Byte.hpp>
+
+#include <rodos_no_using_namespace.h>
+
+#include <etl/vector.h>
+
+#include <cstdint>
+
+
+std::uint32_t printfMask = 0;
+
+
+namespace sts1cobcsw
+{
+using serial::Byte;
+
+periphery::Edu edu = periphery::Edu();
+
+
+class HelloWorld : public RODOS::StaticThread<>
+{
+    void run() override
+    {
+        printfMask = 1;
+        RODOS::PRINTF("Hello, World!\n");
+
+        // Create command
+        auto command = etl::vector<serial::Byte, commandSize>();
+
+        // Start character
+        command.push_back(static_cast<Byte>('a'));
+
+        // UTC
+        command.push_back(static_cast<Byte>(0x80));
+        command.push_back(static_cast<Byte>(0x00));
+        command.push_back(static_cast<Byte>(0x92));
+        command.push_back(static_cast<Byte>(0x65));
+
+        // Command ID
+        command.push_back(static_cast<Byte>(0x34));
+
+        // Length
+        command.push_back(static_cast<Byte>(0x14));
+        command.push_back(static_cast<Byte>(0x00));
+
+        // Queue entry  1
+        // Program ID : 1
+        // Queue ID   : 16
+        // Start time : 1048577
+        // Timeout    : 2
+        command.push_back(static_cast<Byte>(0x01));
+        command.push_back(static_cast<Byte>(0x00));
+        command.push_back(static_cast<Byte>(0x10));
+        command.push_back(static_cast<Byte>(0x00));
+        command.push_back(static_cast<Byte>(0x01));
+        command.push_back(static_cast<Byte>(0x00));
+        command.push_back(static_cast<Byte>(0x10));
+        command.push_back(static_cast<Byte>(0x00));
+        command.push_back(static_cast<Byte>(0x01));
+        command.push_back(static_cast<Byte>(0x00));
+
+        // Queue entry  2
+        // Program ID : 2
+        // Queue ID   : 32
+        // Start time : 2097154
+        // Timeout    : 2
+        command.push_back(static_cast<Byte>(0x02));
+        command.push_back(static_cast<Byte>(0x00));
+        command.push_back(static_cast<Byte>(0x20));
+        command.push_back(static_cast<Byte>(0x00));
+        command.push_back(static_cast<Byte>(0x02));
+        command.push_back(static_cast<Byte>(0x00));
+        command.push_back(static_cast<Byte>(0x20));
+        command.push_back(static_cast<Byte>(0x00));
+        command.push_back(static_cast<Byte>(0x02));
+        command.push_back(static_cast<Byte>(0x00));
+
+        while(not command.full())
+        {
+            command.push_back(static_cast<Byte>(0x00));
+        }
+        // RODOS::PRINTF("Command Size = %d\n", command.size());
+        DispatchCommand(command);
+
+
+        RODOS::hwResetAndReboot();
+    }
+} helloWorld;
+}

--- a/Tests/GoldenTests/DispatchCommand.test.cpp
+++ b/Tests/GoldenTests/DispatchCommand.test.cpp
@@ -24,7 +24,6 @@ class HelloWorld : public RODOS::StaticThread<>
     void run() override
     {
         printfMask = 1;
-        RODOS::PRINTF("Hello, World!\n");
 
         // Create command
         auto command = etl::vector<serial::Byte, commandSize>();

--- a/Tests/GoldenTests/DispatchCommand.test.cpp
+++ b/Tests/GoldenTests/DispatchCommand.test.cpp
@@ -15,12 +15,20 @@ std::uint32_t printfMask = 0;
 namespace sts1cobcsw
 {
 using serial::Byte;
+using serial::operator""_b;
+
 
 periphery::Edu edu = periphery::Edu();
 
 
-class HelloWorld : public RODOS::StaticThread<>
+class DispatchCommandTest : public RODOS::StaticThread<>
 {
+public:
+    DispatchCommandTest() : StaticThread("DispatchCommandTest")
+    {
+    }
+
+private:
     void run() override
     {
         printfMask = 1;
@@ -32,59 +40,58 @@ class HelloWorld : public RODOS::StaticThread<>
         command.push_back(static_cast<Byte>('a'));
 
         // UTC
-        command.push_back(static_cast<Byte>(0x80));
-        command.push_back(static_cast<Byte>(0x00));
-        command.push_back(static_cast<Byte>(0x92));
-        command.push_back(static_cast<Byte>(0x65));
+        command.push_back(0x80_b);
+        command.push_back(0x00_b);
+        command.push_back(0x92_b);
+        command.push_back(0x65_b);
 
         // Command ID
-        command.push_back(static_cast<Byte>(0x34));
+        command.push_back(0x34_b);
 
         // Length
-        command.push_back(static_cast<Byte>(0x14));
-        command.push_back(static_cast<Byte>(0x00));
+        command.push_back(0x14_b);
+        command.push_back(0x00_b);
 
         // Queue entry  1
         // Program ID : 1
         // Queue ID   : 16
         // Start time : 1048577
         // Timeout    : 2
-        command.push_back(static_cast<Byte>(0x01));
-        command.push_back(static_cast<Byte>(0x00));
-        command.push_back(static_cast<Byte>(0x10));
-        command.push_back(static_cast<Byte>(0x00));
-        command.push_back(static_cast<Byte>(0x01));
-        command.push_back(static_cast<Byte>(0x00));
-        command.push_back(static_cast<Byte>(0x10));
-        command.push_back(static_cast<Byte>(0x00));
-        command.push_back(static_cast<Byte>(0x01));
-        command.push_back(static_cast<Byte>(0x00));
+        command.push_back(0x01_b);
+        command.push_back(0x00_b);
+        command.push_back(0x10_b);
+        command.push_back(0x00_b);
+        command.push_back(0x01_b);
+        command.push_back(0x00_b);
+        command.push_back(0x10_b);
+        command.push_back(0x00_b);
+        command.push_back(0x01_b);
+        command.push_back(0x00_b);
 
         // Queue entry  2
         // Program ID : 2
         // Queue ID   : 32
         // Start time : 2097154
         // Timeout    : 2
-        command.push_back(static_cast<Byte>(0x02));
-        command.push_back(static_cast<Byte>(0x00));
-        command.push_back(static_cast<Byte>(0x20));
-        command.push_back(static_cast<Byte>(0x00));
-        command.push_back(static_cast<Byte>(0x02));
-        command.push_back(static_cast<Byte>(0x00));
-        command.push_back(static_cast<Byte>(0x20));
-        command.push_back(static_cast<Byte>(0x00));
-        command.push_back(static_cast<Byte>(0x02));
-        command.push_back(static_cast<Byte>(0x00));
+        command.push_back(0x02_b);
+        command.push_back(0x00_b);
+        command.push_back(0x20_b);
+        command.push_back(0x00_b);
+        command.push_back(0x02_b);
+        command.push_back(0x00_b);
+        command.push_back(0x20_b);
+        command.push_back(0x00_b);
+        command.push_back(0x02_b);
+        command.push_back(0x00_b);
 
         while(not command.full())
         {
-            command.push_back(static_cast<Byte>(0x00));
+            command.push_back(0x00_b);
         }
         // RODOS::PRINTF("Command Size = %d\n", command.size());
         DispatchCommand(command);
 
-
         RODOS::hwResetAndReboot();
     }
-} helloWorld;
+} dispatchCommandTest;
 }

--- a/Tests/GoldenTests/ExpectedOutputs/DispatchCommand.txt
+++ b/Tests/GoldenTests/ExpectedOutputs/DispatchCommand.txt
@@ -1,0 +1,19 @@
+Hello, World!
+Header start character : a
+Header commandID       : 52
+Header utc             : 1704067200
+Header length          : 20
+DateUTC(DD/MM/YYYY HH:MIN:SS) : 01/01/2024 00:00:00
+Entering build queue command parsing
+Printing and parsing
+Prog ID      : 1
+Queue ID     : 16
+Start Time   : 1048577
+Timeout      : 1
+Prog ID      : 2
+Queue ID     : 32
+Start Time   : 2097154
+Timeout      : 2
+Queue index reset. Current size of EDU program queue is 2.
+Call to ResumeEduProgramQueueThread()
+hw_resetAndReboot() -> exit

--- a/Tests/GoldenTests/ExpectedOutputs/DispatchCommand.txt
+++ b/Tests/GoldenTests/ExpectedOutputs/DispatchCommand.txt
@@ -1,4 +1,3 @@
-Hello, World!
 Header start character : a
 Header commandID       : 52
 Header utc             : 1704067200

--- a/Tests/UnitTests/Serial.test.cpp
+++ b/Tests/UnitTests/Serial.test.cpp
@@ -11,6 +11,7 @@
 
 namespace ts = type_safe;
 
+// NOLINTBEGIN(misc-unused-using-decls)
 using ts::operator""_i8;
 using ts::operator""_u8;
 using ts::operator""_i16;
@@ -19,6 +20,7 @@ using ts::operator""_i32;
 using ts::operator""_u32;
 using ts::operator""_i64;
 using ts::operator""_u64;
+// NOLINTEND(misc-unused-using-decls)
 
 using sts1cobcsw::serial::Byte;
 using sts1cobcsw::serial::operator""_b;
@@ -195,7 +197,7 @@ TEST_CASE("(De-)Serialize user-defined types")
     REQUIRE(int(sBuffer[4]) == 0x34);
     REQUIRE(int(sBuffer[5]) == 0x12);
 
-    auto s = Deserialize<S>(sBuffer);
+    auto s = Deserialize<S>(sBuffer);  // NOLINT(readability-identifier-length)
     REQUIRE(s.u16.get() == 0xABCD);
     REQUIRE(s.i32.get() == 0x12345678);
 }


### PR DESCRIPTION
### Description

Use `etl::vector` as the type of command, instead of `etl::string`. Additionally, put parsing functions in their own .cpp file, in order to facilitate testing.

Fixes #29 
Fixes #33 

