### PR TITLE
Always specify a dummy NSS pin to fix RF-EDU issue

### DIFF
--- a/Sts1CobcSw/Hal/IoNames.hpp
+++ b/Sts1CobcSw/Hal/IoNames.hpp
@@ -48,4 +48,8 @@ inline constexpr auto rfSdnPin = pb14;
 inline constexpr auto rfGpio0Pin = pc6;
 inline constexpr auto rfGpio1Pin = pc8;
 inline constexpr auto rfPaEnablePin = pc9;
+
+// We don't need/use NSS pins but due to a bug in Rodos we must specify one so we choose this
+// unconnected pin.
+inline constexpr auto spiNssDummyPin = pa0;
 }

--- a/Sts1CobcSw/Periphery/Flash.cpp
+++ b/Sts1CobcSw/Periphery/Flash.cpp
@@ -51,8 +51,11 @@ constexpr auto sectorErase4ByteAddress = 0x21_b;
 
 auto csGpioPin = hal::GpioPin(hal::flashCsPin);
 auto writeProtectionGpioPin = hal::GpioPin(hal::flashWriteProtectionPin);
-auto spi = RODOS::HAL_SPI(
-    hal::flashSpiIndex, hal::flashSpiSckPin, hal::flashSpiMisoPin, hal::flashSpiMosiPin);
+auto spi = RODOS::HAL_SPI(hal::flashSpiIndex,
+                          hal::flashSpiSckPin,
+                          hal::flashSpiMisoPin,
+                          hal::flashSpiMosiPin,
+                          hal::spiNssDummyPin);
 
 
 // --- Private function declarations ---

--- a/Sts1CobcSw/Periphery/Fram.cpp
+++ b/Sts1CobcSw/Periphery/Fram.cpp
@@ -26,8 +26,11 @@ constexpr auto readDeviceId = 0x9F_b;
 }
 
 auto csGpioPin = hal::GpioPin(hal::framCsPin);
-auto spi = RODOS::HAL_SPI(
-    hal::framEpsSpiIndex, hal::framEpsSpiSckPin, hal::framEpsSpiMisoPin, hal::framEpsSpiMosiPin);
+auto spi = RODOS::HAL_SPI(hal::framEpsSpiIndex,
+                          hal::framEpsSpiSckPin,
+                          hal::framEpsSpiMisoPin,
+                          hal::framEpsSpiMosiPin,
+                          hal::spiNssDummyPin);
 
 
 // --- Private function declarations ---

--- a/Tests/HardwareTests/Spi.test.cpp
+++ b/Tests/HardwareTests/Spi.test.cpp
@@ -38,13 +38,21 @@ using RODOS::PRINTF;
 
 namespace sts1cobcsw
 {
-auto spis = std::array{
-    HAL_SPI(hal::flashSpiIndex, hal::flashSpiSckPin, hal::flashSpiMisoPin, hal::flashSpiMosiPin),
-    HAL_SPI(hal::rfSpiIndex, hal::rfSpiSckPin, hal::rfSpiMisoPin, hal::rfSpiMosiPin),
-    HAL_SPI(hal::framEpsSpiIndex,
-            hal::framEpsSpiSckPin,
-            hal::framEpsSpiMisoPin,
-            hal::framEpsSpiMosiPin)};
+auto spis = std::array{HAL_SPI(hal::flashSpiIndex,
+                               hal::flashSpiSckPin,
+                               hal::flashSpiMisoPin,
+                               hal::flashSpiMosiPin,
+                               hal::spiNssDummyPin),
+                       HAL_SPI(hal::rfSpiIndex,
+                               hal::rfSpiSckPin,
+                               hal::rfSpiMisoPin,
+                               hal::rfSpiMosiPin,
+                               hal::spiNssDummyPin),
+                       HAL_SPI(hal::framEpsSpiIndex,
+                               hal::framEpsSpiSckPin,
+                               hal::framEpsSpiMisoPin,
+                               hal::framEpsSpiMosiPin,
+                               hal::spiNssDummyPin)};
 
 
 class SpiTest : public RODOS::StaticThread<>


### PR DESCRIPTION
### Description

The RF-EDU issue is actually an issue between all SPIs and UART1, the EDU UART. When an SPI is initialized, the default value for the NSS pin (`GPIO_INVALID`) is not handled correctly and sets PA15 to the alternative function AF05. This fucks up the configuration for UART1, where we use PA15 as TX pin.

See [issue 45](https://gitlab.com/rodos/rodos/-/issues/45) in the Rodos repository for even more details.

Fixes #127
