### PR TITLE
Fix codespell errors

### DIFF
--- a/.codespell-ignore
+++ b/.codespell-ignore
@@ -1,1 +1,2 @@
 tust
+fram

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
 {
     "name": "STS1 COBC Full",
-    "image": "tuwienspaceteam/sts1-cobc:1.2.0"
+    "image": "tuwienspaceteam/sts1-cobc:1.3.0"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
       with:
         python-version: "3.8"
 
-    - name: Install codespell
-      run: pip3 install codespell
-
     - name: Format check
       run: cmake -D FORMAT_COMMAND=clang-format -P cmake/format.cmake
 

--- a/Sts1CobcSw/FileSystem/FileSystem.cpp
+++ b/Sts1CobcSw/FileSystem/FileSystem.cpp
@@ -40,7 +40,7 @@ auto lookaheadBuffer = std::array<Byte, pageSize>{};
 // TODO: Check if they need to be global
 lfs_t lfs{};
 lfs_file_t lfsFile{};
-// TODO: Maybe add a conifg header to set things like NAME_MAX or whatever. That could safe a bit of
+// TODO: Maybe add a config header to set things like NAME_MAX or whatever. That could safe a bit of
 // RAM.
 lfs_config const lfsConfig{.read = &Read,
                            .prog = &Program,


### PR DESCRIPTION
### Description

Update the devcontainer to version 1.3.0. This also contains a new codespell version which finds new spelling errors which are mostly false positives (FRAM -> FRAME, etc.). This PR fixes all those issues.

Fixes #160
