### PR TITLE
Make clang-tidy cache work with CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,17 @@ jobs:
     container: tuwienspaceteam/sts1-cobc:latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
+    - uses: actions/cache/restore@v3
+      id: restorecache
+      with:
+        path: /.cache/clang-tidy
+        key: ctcache
+
+    - name: Echo cache miss
+      if: steps.restorecache.outputs.cache-hit != 'true'
+      run: echo "Cache miss"
 
     - name: Configure
       run: cmake --preset=ci-cobc
@@ -109,6 +119,12 @@ jobs:
 
     - name: Build tests
       run: cmake --build build/cobc -t AllTests -j 2
+
+    - uses: actions/cache/save@v3
+      id: savecache
+      with:
+        path: /.cache/clang-tidy
+        key: ctcache
 
     - name: Upload artifacts
       if: github.event_name == 'push' || github.event_name == 'pull_request'


### PR DESCRIPTION
<!--
The PR title must be written as if it is the subject line of a commit that contains the entire PR code. See https://cbea.ms/git-commit/#seven-rules for how to write commit messages. If the PR fixes a single issue you can also use the issue title.
-->

### Description

Restore clang-tidy cache before building `cobc` target, and save it afterwards.
Since building for `linux-x86` takes ~20 seconds, we cannot save much time, but for `cobc`, there is a gain of 30 seconds (see difference between the [first attempt](https://github.com/SpaceTeam/STS1_COBC_SW/actions/runs/6862192182/attempts/1) and the [second attempt (with cache)](https://github.com/SpaceTeam/STS1_COBC_SW/actions/runs/6862192182)).

Cache can be viewed here : https://github.com/SpaceTeam/STS1_COBC_SW/actions/caches

<!--
A brief summery of the changes. You do not need to repeat the description of the related issues. Instead consider explaining why you implemented something the way you did. For simple PRs it might be sufficient to just mention the issues it fixes.
-->

<!-- Mention all issues that the PR fixes like so: -->
Fixes #163 
