### PR TITLE
Fix some warnings

### DIFF
--- a/Sts1CobcSw/Edu/Edu.cpp
+++ b/Sts1CobcSw/Edu/Edu.cpp
@@ -85,7 +85,7 @@ auto Initialize() -> void
 
 auto TurnOn() -> void
 {
-    persistentstate::EduShouldBePowered(true);
+    persistentstate::EduShouldBePowered(/*value=*/true);
     eduEnableGpioPin.Set();
 
     // TODO: Test how high we can set the baudrate without problems (bit errors, etc.)
@@ -96,7 +96,7 @@ auto TurnOn() -> void
 
 auto TurnOff() -> void
 {
-    persistentstate::EduShouldBePowered(false);
+    persistentstate::EduShouldBePowered(/*value=*/false);
     eduEnableGpioPin.Reset();
     uart.reset();
 }

--- a/Sts1CobcSw/EduHeartbeatThread.cpp
+++ b/Sts1CobcSw/EduHeartbeatThread.cpp
@@ -71,7 +71,7 @@ private:
         auto oldHeartbeat = eduHeartbeatGpioPin.Read();
         auto edgeCounter = 0;
 
-        RODOS::PRINTF("Sampling period : %lld\n", samplingPeriod / MILLISECONDS);
+        RODOS::PRINTF("Sampling period : %" PRIi64 "\n", samplingPeriod / MILLISECONDS);
         auto toggle = true;
         TIME_LOOP(0, samplingPeriod)
         {

--- a/Sts1CobcSw/EduPowerManagementThread.cpp
+++ b/Sts1CobcSw/EduPowerManagementThread.cpp
@@ -63,7 +63,7 @@ private:
                 if(eduIsAlive)
                 {
                     // TODO: also perform a check about archives on cobc
-                    if(!eduHasUpdate && startDelay >= startDelayLimit)
+                    if((not eduHasUpdate) and (startDelay >= startDelayLimit))
                     {
                         RODOS::PRINTF("Turning Edu off\n");
                         edu::TurnOff();

--- a/Sts1CobcSw/EduProgramQueueThread.cpp
+++ b/Sts1CobcSw/EduProgramQueueThread.cpp
@@ -53,7 +53,7 @@ private:
         // eduProgramQueue.push_back(queueEntry1);
         // eduProgramQueue.push_back(queueEntry2);
 
-        RODOS::PRINTF("Size of EduProgramQueue : %d\n", edu::programQueue.size());
+        RODOS::PRINTF("Size of EduProgramQueue : %zu\n", edu::programQueue.size());
     }
 
     void run() override

--- a/Sts1CobcSw/FileSystem/FileSystem.cpp
+++ b/Sts1CobcSw/FileSystem/FileSystem.cpp
@@ -42,7 +42,9 @@ lfs_t lfs{};
 lfs_file_t lfsFile{};
 // TODO: Maybe add a config header to set things like NAME_MAX or whatever. That could safe a bit of
 // RAM.
-lfs_config const lfsConfig{.read = &Read,
+lfs_config const lfsConfig{.context = nullptr,
+
+                           .read = &Read,
                            .prog = &Program,
                            .erase = &Erase,
                            .sync = &Sync,
@@ -57,7 +59,12 @@ lfs_config const lfsConfig{.read = &Read,
 
                            .read_buffer = data(readBuffer),
                            .prog_buffer = data(programBuffer),
-                           .lookahead_buffer = data(lookaheadBuffer)};  // NOLINT
+                           .lookahead_buffer = data(lookaheadBuffer),
+
+                           .name_max = LFS_NAME_MAX,
+                           .file_max = LFS_FILE_MAX,
+                           .attr_max = LFS_ATTR_MAX,
+                           .metadata_max = flash::sectorSize};
 
 
 // --- Public function definitions ---


### PR DESCRIPTION
### Description

Fix some warnings when building for the COBC targets (without tests):

- Fix missing initializers warnings in FileSystem.cpp
- Fix printing type specifiers in various files

Fixes parts of #134
