### PR TITLE
Add second test for external watchdog timer

### DIFF
--- a/Sts1CobcSw/Hal/IoNames.hpp
+++ b/Sts1CobcSw/Hal/IoNames.hpp
@@ -11,6 +11,8 @@ namespace sts1cobcsw::hal
 inline constexpr auto led1Pin = pb12;
 inline constexpr auto led2Pin = pb15;
 
+inline constexpr auto watchdogClearPin = pa9;
+
 inline constexpr auto epsBatteryGoodPin = pc15;
 inline constexpr auto epsChargingPin = pc14;
 

--- a/Tests/HardwareTests/CMakeLists.txt
+++ b/Tests/HardwareTests/CMakeLists.txt
@@ -39,6 +39,9 @@ target_link_libraries(Sts1CobcSwTests_Uart PRIVATE rodos::rodos Sts1CobcSw_Hal)
 add_program(Watchdog Watchdog.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Watchdog PRIVATE rodos::rodos Sts1CobcSw_Hal)
 
+add_program(WatchdogClear Watchdog.test.cpp WatchdogClear.test.cpp)
+target_link_libraries(Sts1CobcSwTests_WatchdogClear PRIVATE rodos::rodos Sts1CobcSw_Hal)
+
 get_property(
     top_level_hw_test_targets
     DIRECTORY ${CMAKE_CURRENT_LIST_DIR}

--- a/Tests/HardwareTests/Watchdog.test.cpp
+++ b/Tests/HardwareTests/Watchdog.test.cpp
@@ -6,22 +6,22 @@
 
 namespace sts1cobcsw
 {
-auto ledGpio = hal::GpioPin(hal::led1Pin);
+static auto led1Gpio = hal::GpioPin(hal::led1Pin);
 
 
 class WatchdogTest : public RODOS::StaticThread<>
 {
     void init() override
     {
-        ledGpio.Direction(hal::PinDirection::out);
+        led1Gpio.Direction(hal::PinDirection::out);
     }
 
 
     void run() override
     {
-        ledGpio.Reset();
+        led1Gpio.Reset();
         RODOS::AT(RODOS::NOW() + 800 * RODOS::MILLISECONDS);
-        ledGpio.Set();
+        led1Gpio.Set();
     }
 } watchdogTest;
 }

--- a/Tests/HardwareTests/WatchdogClear.test.cpp
+++ b/Tests/HardwareTests/WatchdogClear.test.cpp
@@ -1,0 +1,41 @@
+#include <Sts1CobcSw/Hal/GpioPin.hpp>
+#include <Sts1CobcSw/Hal/IoNames.hpp>
+
+#include <rodos_no_using_namespace.h>
+
+
+namespace sts1cobcsw
+{
+static auto led2Gpio = hal::GpioPin(hal::led2Pin);
+static auto watchdogClearGpio = hal::GpioPin(hal::watchdogClearPin);
+
+
+class WatchdogClearTest : public RODOS::StaticThread<>
+{
+    void init() override
+    {
+        led2Gpio.Direction(hal::PinDirection::out);
+        watchdogClearGpio.Direction(hal::PinDirection::out);
+    }
+
+
+    void run() override
+    {
+        auto toggle = true;
+        TIME_LOOP(0, 800 * RODOS::MILLISECONDS)
+        {
+            if(toggle)
+            {
+                led2Gpio.Reset();
+                watchdogClearGpio.Reset();
+            }
+            else
+            {
+                led2Gpio.Set();
+                watchdogClearGpio.Set();
+            }
+            toggle = not toggle;
+        }
+    }
+} watchdogClearTest;
+}


### PR DESCRIPTION
### Description

The new test periodically clears the watchdog timer to prevent it from resetting the COBC.
