### PR TITLE
Refactor RF function to read part info

### DIFF
--- a/Sts1CobcSw/Periphery/Flash.cpp
+++ b/Sts1CobcSw/Periphery/Flash.cpp
@@ -222,8 +222,8 @@ auto DisableWriting() -> void
 
 
 // TODO:: Maybe this is one level of indirection too much?
-template<std::size_t nBytes>
-inline auto Write(std::span<Byte const, nBytes> data) -> void
+template<std::size_t extent>
+inline auto Write(std::span<Byte const, extent> data) -> void
 {
     hal::WriteTo(&spi, data);
 }

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -12,7 +12,7 @@
 #include <span>
 
 
-namespace sts1cobcsw::periphery::rf
+namespace sts1cobcsw::rf
 {
 using RODOS::AT;
 using RODOS::MICROSECONDS;

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -637,7 +637,7 @@ auto Initialize(TxType txType) -> void
 }
 
 
-auto ReadPartInfo() -> std::uint16_t
+auto ReadPartNumber() -> std::uint16_t
 {
     auto sendBuffer = std::to_array<Byte>({cmdPartInfo});
     auto responseBuffer = SendCommandWithResponse<partInfoResponseLength>(Span(sendBuffer));

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -671,13 +671,7 @@ auto InitializeGpioAndSpi() -> void
     watchdogResetGpioPin.Reset();
 
     constexpr auto baudrate = 10'000'000;
-    auto spiError = spi.init(baudrate, /*slave=*/false, /*tiMode=*/false);
-    if(spiError == -1)
-    {
-        RODOS::PRINTF("Error initializing RF SPI!\n");
-        // TODO: proper error handling
-        return;
-    }
+    hal::Initialize(&spi, baudrate);
 
     // Enable Si4463 and wait for PoR to finish
     AT(NOW() + porCircuitSettlePause);

--- a/Sts1CobcSw/Periphery/Rf.hpp
+++ b/Sts1CobcSw/Periphery/Rf.hpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 
 
-namespace sts1cobcsw::periphery::rf
+namespace sts1cobcsw::rf
 {
 enum class TxType
 {

--- a/Sts1CobcSw/Periphery/Rf.hpp
+++ b/Sts1CobcSw/Periphery/Rf.hpp
@@ -14,5 +14,5 @@ enum class TxType
 
 
 auto Initialize(TxType txType) -> void;
-auto ReadPartInfo() -> std::uint16_t;
+auto ReadPartNumber() -> std::uint16_t;
 }

--- a/Tests/HardwareTests/Rf.test.cpp
+++ b/Tests/HardwareTests/Rf.test.cpp
@@ -32,10 +32,10 @@ private:
         PRINTF("RF module initialized\n");
 
         PRINTF("\n");
-        auto correctPartInfo = 0x4463;
-        auto partInfo = rf::ReadPartInfo();
-        PRINTF("Part info: 0x%4x == 0x%4x\n", partInfo, correctPartInfo);
-        Check(partInfo == correctPartInfo);
+        auto correctPartNumber = 0x4463;
+        auto partNumber = rf::ReadPartNumber();
+        PRINTF("Part number: 0x%4x == 0x%4x\n", partNumber, correctPartNumber);
+        Check(partNumber == correctPartNumber);
 
         // Here comes the rest of the RF test
     }

--- a/Tests/HardwareTests/Rf.test.cpp
+++ b/Tests/HardwareTests/Rf.test.cpp
@@ -28,12 +28,12 @@ private:
     {
         PRINTF("\nRF test\n\n");
 
-        periphery::rf::Initialize(periphery::rf::TxType::morse);
+        rf::Initialize(rf::TxType::morse);
         PRINTF("RF module initialized\n");
 
         PRINTF("\n");
         auto correctPartInfo = 0x4463;
-        auto partInfo = periphery::rf::ReadPartInfo();
+        auto partInfo = rf::ReadPartInfo();
         PRINTF("Part info: 0x%4x == 0x%4x\n", partInfo, correctPartInfo);
         Check(partInfo == correctPartInfo);
 


### PR DESCRIPTION
### Description

All parts that are directly related to `ReadPartInfo()` have been refactored (e.g. with `Span()` or the new SPI initialization function). Magic numbers related to timings have been replaced in non-related parts out of convenience.

Fixes #225
