### PR TITLE
Add initialize function for EPS sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,10 @@ cmake --build --preset=dev-cobc --target Sts1CobcSwTests_Fram
 The following ideas are mainly stolen from [P1204R0 – Canonical Project
 Structure](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1204r0.html).
 
-- "All" file and folder names uses UpperCamalCase (unfortunately cmake-init uses different
+- "All" file and folder names uses UpperCamelCase (unfortunately cmake-init uses different
   cases, so this is a lot to change and `docs/` or `cmake/` might stay in the wrong case
   for a while).
-- Top level directory is project name in UpperCamalCase or GitHub repo name (unfortunately
+- Top level directory is project name in UpperCamelCase or GitHub repo name (unfortunately
   we use a different naming convention with SHOUTING_CASE on GitHub).
 - Source code is in subdirectory named after the project (no GitHub name this time and no
   `Source` or `Include` folders).

--- a/Sts1CobcSw/Hal/IoNames.hpp
+++ b/Sts1CobcSw/Hal/IoNames.hpp
@@ -40,9 +40,9 @@ inline constexpr auto framEpsSpiSckPin = pc10;
 inline constexpr auto framEpsSpiMisoPin = pc11;
 inline constexpr auto framEpsSpiMosiPin = pc12;
 inline constexpr auto framCsPin = pb13;
-inline constexpr auto epsCs1Pin = pd2;
-inline constexpr auto epsCs2Pin = pb4;
-inline constexpr auto epsCs3Pin = pb5;
+inline constexpr auto epsAdc4CsPin = pd2;
+inline constexpr auto epsAdc5CsPin = pb4;
+inline constexpr auto epsAdc6CsPin = pb5;
 
 inline constexpr auto rfSpiIndex = RODOS::SPI_IDX2;
 inline constexpr auto rfSpiSckPin = pc7;

--- a/Sts1CobcSw/Hal/IoNames.hpp
+++ b/Sts1CobcSw/Hal/IoNames.hpp
@@ -40,6 +40,9 @@ inline constexpr auto framEpsSpiSckPin = pc10;
 inline constexpr auto framEpsSpiMisoPin = pc11;
 inline constexpr auto framEpsSpiMosiPin = pc12;
 inline constexpr auto framCsPin = pb13;
+inline constexpr auto epsCs1Pin = pd2;
+inline constexpr auto epsCs2Pin = pb4;
+inline constexpr auto epsCs3Pin = pb5;
 
 inline constexpr auto rfSpiIndex = RODOS::SPI_IDX2;
 inline constexpr auto rfSpiSckPin = pc7;

--- a/Sts1CobcSw/Periphery/CMakeLists.txt
+++ b/Sts1CobcSw/Periphery/CMakeLists.txt
@@ -1,7 +1,7 @@
 target_link_libraries(Sts1CobcSw_Periphery PUBLIC rodos::rodos Sts1CobcSw_Serial)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Generic)
-    target_sources(Sts1CobcSw_Periphery PRIVATE PersistentState.cpp Flash.cpp Fram.cpp Rf.cpp)
+    target_sources(Sts1CobcSw_Periphery PRIVATE PersistentState.cpp Flash.cpp Fram.cpp Rf.cpp Eps.cpp)
     target_link_libraries(Sts1CobcSw_Periphery PRIVATE Sts1CobcSw_Utility)
     target_link_libraries(Sts1CobcSw_Periphery PUBLIC Sts1CobcSw_Hal)
 endif()

--- a/Sts1CobcSw/Periphery/CMakeLists.txt
+++ b/Sts1CobcSw/Periphery/CMakeLists.txt
@@ -1,7 +1,9 @@
 target_link_libraries(Sts1CobcSw_Periphery PUBLIC rodos::rodos Sts1CobcSw_Serial)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Generic)
-    target_sources(Sts1CobcSw_Periphery PRIVATE PersistentState.cpp Flash.cpp Fram.cpp Rf.cpp Eps.cpp)
+    target_sources(
+        Sts1CobcSw_Periphery PRIVATE PersistentState.cpp Flash.cpp Fram.cpp Rf.cpp Eps.cpp
+    )
     target_link_libraries(Sts1CobcSw_Periphery PRIVATE Sts1CobcSw_Utility)
     target_link_libraries(Sts1CobcSw_Periphery PUBLIC Sts1CobcSw_Hal)
 endif()

--- a/Sts1CobcSw/Periphery/Eps.cpp
+++ b/Sts1CobcSw/Periphery/Eps.cpp
@@ -1,33 +1,133 @@
+#include <Sts1CobcSw/Hal/GpioPin.hpp>
 #include <Sts1CobcSw/Hal/IoNames.hpp>
 #include <Sts1CobcSw/Hal/Spi.hpp>
+#include <Sts1CobcSw/Periphery/Eps.hpp>
+#include <Sts1CobcSw/Serial/Byte.hpp>
+#include <Sts1CobcSw/Utility/Span.hpp>
 
 #include <rodos_no_using_namespace.h>
 
 namespace sts1cobcsw::periphery::eps
 {
+// TODO: ask David F.
+// STS_EPS_ADCS schematics do not match Wiki description
+// EPS ADC channel info:
+// Pin   | ADC4 (CS1)
+//--------------------------------
+// AIN0  | Panel Y+ Cell 1 Voltage
+// AIN1  | Panel Y+ Cell 2 Voltage
+// AIN2  | Panel Y- Cell 1 Voltage
+// AIN3  | Panel Y- Cell 2 Voltage
+// AIN4  | Panel X+ Cell 1 Voltage
+// AIN5  | Panel X- Cell 1 Voltage
+// AIN6  | Panel Z- Cell 1 Voltage
+// AIN7  | Panel Z- Cell 2 Voltage
+// AIN8  | Panel Y+ Cell 1 Current
+// AIN9  | Panel Y+ Cell 2 Current
+// AIN10 | Panel Y- Cell 1 Current
+// AIN11 | Panel Y- Cell 2 Current
+// AIN12 | Panel X+ Cell 1 Current
+// AIN13 | Panel X- Cell 1 Current
+// AIN14 | Panel Z- Cell 1 Current
+// AIN15 | Panel Z- Cell 2 Current
+
+// Pin   | ADC5 (CS2)
+//--------------------------------
+// AIN0  | BATT_SCALED
+// AIN1  | Battery Center Tap
+// AIN2  | Battery Pack Current
+// AIN3  | Battery Temperature
+// AIN4  | Panel Y+ Temperature
+// AIN5  | Panel Y- Temperature
+// AIN6  | Panel X+ Temperature
+// AIN7  | Panel X- Temperature
+// AIN8  | Panel Z- Temperature
+// AIN9  | VOUT_I
+// AIN10 | GND
+// AIN11 | GND
+// AIN12 | GND
+// AIN13 | GND
+// AIN14 | GND
+// AIN15 | BATT_RAW_SCALED
+
+// Pin   | ADC6 (CS3)
+//--------------------------------
+// AIN0  | MPPT Bus Current
+// AIN1  | Panel X+ MPPT 1 Current
+// AIN2  | Panel Y+ MPPT 2 Current
+// AIN3  | Panel Y- MPPT 1 Current
+// AIN4  | Panel Y- MPPT 2 Current
+// AIN5  | Panel Y+ MPPT 1 Current
+// AIN6  | Panel X- MPPT 1 Current
+// AIN7  | Panel Z- MPPT 1 Current
+// AIN8  | Panel Z- MPPT 2 Current
+// AIN9  | MPPT Bus Voltage
+// AIN10 | GND
+// AIN11 | GND
+// AIN12 | GND
+// AIN13 | GND
+// AIN14 | GND
+// AIN15 | GND
+
+
 // --- Private globals ---
 
-auto epsSpi = HAL_SPI(framEpsSpiIndex, framEpsSpiSckPin, framEpsSpiMisoPin, framEpsSpiMosiPin);
+// MAX11632EEG+T registers
 
-enum class AdcRegister : std::uint8_t
-{
-    conversion = 0b1 << 7,
-    setup = 0b01 << 6,
-    averaging = 0b001 << 5,
-    reset = 0b0001 << 4
-};
+constexpr auto setupRegister = 1_b << 6;
 
-enum class ScanMode : std::uint8_t
-{
-    zeroThroughN = 0b00,
-    nThroughHighest = 0b01,
-    repeatN = 0b10,
-    noScan = 0b11
-};
+// Pins and SPI
+
+auto cs1GpioPin = hal::GpioPin(hal::epsCs1Pin);
+auto cs2GpioPin = hal::GpioPin(hal::epsCs2Pin);
+auto cs3GpioPin = hal::GpioPin(hal::epsCs3Pin);
+auto epsSpi = RODOS::HAL_SPI(
+    hal::framEpsSpiIndex, hal::framEpsSpiSckPin, hal::framEpsSpiMisoPin, hal::framEpsSpiMosiPin);
+
 
 // --- Private function declarations ---
 
+auto SetSetupRegister() -> void;
+
+
 // --- Public function definitions ---
 
+auto Initialize() -> void
+{
+    cs1GpioPin.Direction(hal::PinDirection::out);
+    cs1GpioPin.Set();
+    cs2GpioPin.Direction(hal::PinDirection::out);
+    cs2GpioPin.Set();
+    cs3GpioPin.Direction(hal::PinDirection::out);
+    cs3GpioPin.Set();
+
+    // TODO: Check if external clock mode is ever necessary
+    // Datasheet says 10 MHz max.
+    // TODO: FRAM code sets baudrate to 12 MHz
+    // SCLK can only run up to 4.8 MHz in clock mode 0b11
+    constexpr auto baudrate = 10'000'000;
+    hal::Initialize(&epsSpi, baudrate);
+}
+
+
 // --- Private function definitions ---
+
+auto SetSetupRegister() -> void
+{
+    // Setup register values
+    // [7:6]: Register selection bits = 0b01
+    // [5:4]: Clock mode and CNVST configuration
+    //      Don't use CNVST modes, we use the analog configuration for the CNVST pin
+    //      Therefore clock mode = 0b10 << 4
+    // [3:2]: Reference mode configuration
+    //      Reference off after scan; need wake-up delay: 0b00
+    //      Reference always on; no wake-up delay: 0b10
+    // [1:0]: Don't care
+
+    // Changing to CNVST mode could be bad (analog input in digital pin)
+    constexpr auto clockMode = 0b10_b << 4;
+    constexpr auto referenceMode = 0b00_b;
+    auto setupData = 0_b | setupRegister | clockMode | referenceMode;
+    hal::WriteTo(&epsSpi, Span(setupData));
+}
 }

--- a/Sts1CobcSw/Periphery/Eps.cpp
+++ b/Sts1CobcSw/Periphery/Eps.cpp
@@ -1,0 +1,33 @@
+#include <Sts1CobcSw/Hal/IoNames.hpp>
+#include <Sts1CobcSw/Hal/Spi.hpp>
+
+#include <rodos_no_using_namespace.h>
+
+namespace sts1cobcsw::periphery::eps
+{
+// --- Private globals ---
+
+auto epsSpi = HAL_SPI(framEpsSpiIndex, framEpsSpiSckPin, framEpsSpiMisoPin, framEpsSpiMosiPin);
+
+enum class AdcRegister : std::uint8_t
+{
+    conversion = 0b1 << 7,
+    setup = 0b01 << 6,
+    averaging = 0b001 << 5,
+    reset = 0b0001 << 4
+};
+
+enum class ScanMode : std::uint8_t
+{
+    zeroThroughN = 0b00,
+    nThroughHighest = 0b01,
+    repeatN = 0b10,
+    noScan = 0b11
+};
+
+// --- Private function declarations ---
+
+// --- Public function definitions ---
+
+// --- Private function definitions ---
+}

--- a/Sts1CobcSw/Periphery/Eps.cpp
+++ b/Sts1CobcSw/Periphery/Eps.cpp
@@ -98,7 +98,7 @@ auto Initialize() -> void
     adc6CsGpioPin.Direction(hal::PinDirection::out);
     adc6CsGpioPin.Set();
 
-    constexpr auto baudrate = 10'000'000;
+    constexpr auto baudrate = 6'000'000;
     hal::Initialize(&spi, baudrate);
 
     // Setup ADCs

--- a/Sts1CobcSw/Periphery/Eps.cpp
+++ b/Sts1CobcSw/Periphery/Eps.cpp
@@ -122,7 +122,7 @@ auto ConfigureSetupRegister(hal::GpioPin * adcCsPin) -> void
     //      Reference always on; no wake-up delay: 0b10
     // [1:0]: Don't care
 
-    constexpr auto setupRegister = 01_b;
+    constexpr auto setupRegister = 0b01_b;
     constexpr auto clockMode = 0b10_b;
     constexpr auto referenceMode = 0b00_b;
     constexpr auto setupData = (setupRegister << 6) | (clockMode << 4) | (referenceMode << 2);

--- a/Sts1CobcSw/Periphery/Eps.hpp
+++ b/Sts1CobcSw/Periphery/Eps.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace sts1cobcsw::periphery::eps
+{
+}

--- a/Sts1CobcSw/Periphery/Eps.hpp
+++ b/Sts1CobcSw/Periphery/Eps.hpp
@@ -2,4 +2,5 @@
 
 namespace sts1cobcsw::periphery::eps
 {
+auto Initialize() -> void;
 }

--- a/Sts1CobcSw/Periphery/Eps.hpp
+++ b/Sts1CobcSw/Periphery/Eps.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace sts1cobcsw::periphery::eps
+namespace sts1cobcsw::eps
 {
 auto Initialize() -> void;
 }

--- a/Sts1CobcSw/Periphery/Eps.hpp
+++ b/Sts1CobcSw/Periphery/Eps.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+
 namespace sts1cobcsw::eps
 {
 auto Initialize() -> void;

--- a/Sts1CobcSw/Periphery/Fram.cpp
+++ b/Sts1CobcSw/Periphery/Fram.cpp
@@ -50,7 +50,7 @@ auto Initialize() -> void
     csGpioPin.Direction(hal::PinDirection::out);
     csGpioPin.Set();
 
-    auto const baudRate = 12'000'000;
+    auto const baudRate = 6'000'000;
     hal::Initialize(&spi, baudRate);
 }
 

--- a/Tests/HardwareTests/CMakeLists.txt
+++ b/Tests/HardwareTests/CMakeLists.txt
@@ -15,6 +15,9 @@ target_link_libraries(
                                         Sts1CobcSw_Hal Sts1CobcSw_Edu
 )
 
+add_program(Eps Eps.test.cpp)
+target_link_libraries(Sts1CobcSwTests_Eps PRIVATE rodos::rodos Sts1CobcSw_Periphery)
+
 add_program(FileSystem FileSystem.test.cpp)
 target_link_libraries(
     Sts1CobcSwTests_FileSystem PRIVATE rodos::rodos littlefs::littlefs Sts1CobcSw_FileSystem

--- a/Tests/HardwareTests/CMakeLists.txt
+++ b/Tests/HardwareTests/CMakeLists.txt
@@ -7,7 +7,9 @@ target_include_directories(
 )
 
 add_program(Crc32 Crc32.test.cpp)
-target_link_libraries(Sts1CobcSwTests_Crc32 PRIVATE rodos::rodos Sts1CobcSw_Utility Sts1CobcSwTests_Utility)
+target_link_libraries(
+    Sts1CobcSwTests_Crc32 PRIVATE rodos::rodos Sts1CobcSw_Utility Sts1CobcSwTests_Utility
+)
 
 add_program(EduCommands EduCommands.test.cpp)
 target_link_libraries(
@@ -39,7 +41,9 @@ add_program(Gpio Gpio.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Gpio PRIVATE rodos::rodos Sts1CobcSw_Hal)
 
 add_program(Rf Rf.test.cpp)
-target_link_libraries(Sts1CobcSwTests_Rf PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSwTests_Utility)
+target_link_libraries(
+    Sts1CobcSwTests_Rf PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSwTests_Utility
+)
 
 add_program(Uart Uart.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Uart PRIVATE rodos::rodos Sts1CobcSw_Hal Sts1CobcSw_Utility)

--- a/Tests/HardwareTests/Eps.test.cpp
+++ b/Tests/HardwareTests/Eps.test.cpp
@@ -1,0 +1,37 @@
+#include <Sts1CobcSw/Periphery/Eps.hpp>
+
+#include <rodos_no_using_namespace.h>
+
+
+namespace sts1cobcsw
+{
+using RODOS::PRINTF;
+
+
+class EpsTest : public RODOS::StaticThread<>
+{
+public:
+    EpsTest() : StaticThread("EpsTest")
+    {
+    }
+
+
+private:
+    void init() override
+    {
+    }
+
+
+    void run() override
+    {
+        PRINTF("\nEPS test\n\n");
+
+        eps::Initialize();
+        PRINTF("EPS ADCs initialized\n");
+
+        PRINTF("\n");
+
+        // Here comes the rest of the EPS test
+    }
+} epsTest;
+}


### PR DESCRIPTION
### Description
This PR adds functionality to initialize the EPS ADCs for the COBC, including the necessary pin definitions.

Fixes #212
