### PR TITLE
Refactor RF initialize function

### DIFF
--- a/Sts1CobcSw/Edu/EduMock.cpp
+++ b/Sts1CobcSw/Edu/EduMock.cpp
@@ -1,5 +1,8 @@
-#include <Sts1CobcSw/Edu/Edu.hpp>
+#include <Sts1CobcSw/Edu/Edu.hpp>  // IWYU pragma: associated
+#include <Sts1CobcSw/Edu/Types.hpp>
 #include <Sts1CobcSw/Utility/Time.hpp>
+
+#include <rodos_no_using_namespace.h>
 
 #include <cinttypes>
 

--- a/Sts1CobcSw/FileSystem/FileSystem.cpp
+++ b/Sts1CobcSw/FileSystem/FileSystem.cpp
@@ -5,7 +5,6 @@
 #include <rodos_no_using_namespace.h>
 
 #include <algorithm>
-#include <array>
 #include <iterator>
 #include <span>
 

--- a/Sts1CobcSw/Outcome/Outcome.hpp
+++ b/Sts1CobcSw/Outcome/Outcome.hpp
@@ -8,7 +8,7 @@
     #define SYSTEM_ERROR2_FATAL(msg) RODOS::hwResetAndReboot()
 #endif
 
-#include <outcome-experimental.hpp>
+#include <outcome-experimental.hpp>  // IWYU pragma: export
 
 
 struct RebootPolicy : outcome_v2::experimental::policy::base

--- a/Sts1CobcSw/Periphery/Eps.cpp
+++ b/Sts1CobcSw/Periphery/Eps.cpp
@@ -7,6 +7,8 @@
 
 #include <rodos_no_using_namespace.h>
 
+#include <cstddef>
+
 
 namespace sts1cobcsw::eps
 {

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -734,7 +734,7 @@ auto SetProperties(PropertyGroup propertyGroup,
                    std::span<Byte const> propertyValues) -> void
 {
     auto setPropertiesBuffer = std::array<Byte, setPropertiesHeaderSize + maxNProperties>{};
-    auto nProperties = std::size(propertyValues);
+    auto nProperties = propertyValues.size();
     auto bytesToSend = setPropertiesHeaderSize + nProperties;
 
     setPropertiesBuffer[0] = cmdSetProperty;

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -67,6 +67,7 @@ constexpr std::uint32_t powerUpXoFrequency = 26'000'000;  // 26 MHz
 constexpr auto cmdPartInfo = 0x01_b;
 constexpr auto cmdPowerUp = 0x02_b;
 constexpr auto cmdSetProperty = 0x11_b;
+constexpr auto cmdGpioPinCfg = 0x13_b;
 constexpr auto cmdReadCmdBuff = 0x44_b;
 
 // Command answer lengths
@@ -152,15 +153,7 @@ auto Initialize(TxType txType) -> void
     PowerUp(PowerUpBootOptions::noPatch, PowerUpXtalOptions::xtal, powerUpXoFrequency);
 
     // GPIO Pin Cfg
-    sendBuffer[0] = 0x13;
-    sendBuffer[1] = 0x00;
-    sendBuffer[2] = 0x00;
-    sendBuffer[3] = 0x00;
-    sendBuffer[4] = 0x00;
-    sendBuffer[5] = 0x00;
-    sendBuffer[6] = 0x00;
-    sendBuffer[7] = 0x00;
-    SendCommand(data(sendBuffer), 8, nullptr, 0);
+    SendCommand(Span({cmdGpioPinCfg, 0x00_b, 0x00_b, 0x00_b, 0x00_b, 0x00_b, 0x00_b, 0x00_b}));
 
     // Global XO Tune 2
     sendBuffer[0] = 0x11;

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -627,15 +627,16 @@ auto ReadPartNumber() -> std::uint16_t
 auto SetTxType(TxType txType) -> void
 {
     // Constants for setting the TX type (morse, 2GFSK)
-    constexpr uint32_t dataRateMorse = 20'000U;  // MODEM_DATA_RATE: unused, 20k Baud
-    constexpr uint32_t dataRate2Gfsk =
-        9'600U;  // MODEM_DATA_RATE: For 9k6 Baud: (TX_DATA_RATE * MODEM_TX_NCO_MODE *
-                 // TXOSR)/F_XTAL_Hz = (9600 * 2600000 * 10)/26000000 = 9600 = 0x002580
+    // MODEM_DATA_RATE: unused, 20k Baud
+    constexpr uint32_t dataRateMorse = 20'000U;
+    // MODEM_DATA_RATE: For 9k6 Baud: (TX_DATA_RATE * MODEM_TX_NCO_MODE * TXOSR)/F_XTAL_Hz = (9600 *
+    // 2600000 * 10)/26000000 = 9600 = 0x002580
+    constexpr uint32_t dataRate2Gfsk = 9'600U;
 
-    constexpr auto modemModTypeMorse =
-        0x09_b;  // MODEM_MODE_TYPE: TX data from GPIO0 pin, modulation OOK
-    constexpr auto modemModType2Gfsk =
-        0x03_b;  // MODEM_MODE_TYPE: TX data from packet handler, modulation 2GFSK
+    // MODEM_MODE_TYPE: TX data from GPIO0 pin, modulation OOK
+    constexpr auto modemModTypeMorse = 0x09_b;
+    // MODEM_MODE_TYPE: TX data from packet handler, modulation 2GFSK
+    constexpr auto modemModType2Gfsk = 0x03_b;
 
     auto modemModType = (txType == TxType::morse ? modemModTypeMorse : modemModType2Gfsk);
     auto dataRate = (txType == TxType::morse ? dataRateMorse : dataRate2Gfsk);

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -219,125 +219,101 @@ auto Initialize(TxType txType) -> void
     // Jakob: TODO: Check that pattern!
 
     // CRC Config
-    // SetProperties(PropertyGroup::
-    //                   /*startProperty=*/
-    //               Span({
-
-    //               }));
-    sendBuffer[0] = 0x11;
-    sendBuffer[propertyGroupIndex] = 0x12;
-    sendBuffer[nPropertiesIndex] = 0x01;
-    sendBuffer[startPropertyIndex] = 0x00;
-    sendBuffer[4] = 0x00;  // PKT_CRC_CONFIG: No CRC
-    SendCommand(data(sendBuffer), 5, nullptr, 0);
-
-    // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+    SetProperties(PropertyGroup::pkt,
+                  /*startProperty=*/0x00_b,
+                  Span({
+                      0x00_b  // PKT_CRC_CONFIG: No CRC
+                  }));
 
     // Whitening and Packet Parameters
-    // SetProperties(PropertyGroup::
-    //                   /*startProperty=*/
-    //               Span({
-    sendBuffer[0] = 0x11;
-    sendBuffer[propertyGroupIndex] = 0x12;
-    sendBuffer[nPropertiesIndex] = 0x02;
-    sendBuffer[startPropertyIndex] = 0x05;
-    sendBuffer[4] = 0x00;  // PKT_WHT_BIT_NUM: Disable whitening
-    sendBuffer[5] = 0x01;  // PKT_CONFIG1: Don't split RX and TX field information (length,
-                           // ...), enable RX packet handler, use normal (2)FSK, no Manchester
-                           // coding, no CRC, data transmission with MSB first.
-    SendCommand(data(sendBuffer), 6, nullptr, 0);
+    SetProperties(PropertyGroup::pkt,
+                  /*startProperty=*/0x05_b,
+                  Span({
+                      0x00_b,  // PKT_WHT_BIT_NUM: Disable whitening
+                      0x01_b   // PKT_CONFIG1: Don't split RX and TX field information (length,
+                               // ...), enable RX packet handler, use normal (2)FSK, no Manchester
+                               // coding, no CRC, data transmission with MSB first.
+                  }));
 
     // Pkt Length part 1
-    // SetProperties(PropertyGroup::
-    //                   /*startProperty=*/
-    //               Span({
-    sendBuffer[0] = 0x11;
-    sendBuffer[propertyGroupIndex] = 0x12;
-    sendBuffer[nPropertiesIndex] = 0x0C;
-    sendBuffer[startPropertyIndex] = 0x08;
-    sendBuffer[4] = 0x60;  // PKT_LEN: Infinite receive, big endian (MSB first)
-    sendBuffer[5] = 0x00;  // PKT_LEN_FIELD_SOURCE
-    sendBuffer[6] = 0x00;  // PKT_LEN_ADJUST
-    sendBuffer[7] = 0x30;  // PKT_TX_THRESHOLD: Trigger TX FiFo almost empty interrupt when 0x30
-                           // bytes in FiFo (size 0x40) are empty
-    sendBuffer[8] = 0x30;  // PKT_RX_THRESHOLD: Trigger RX FiFo almost full interrupt when 0x30
-                           // bytes in FiFo (size 0x40) are full
-    sendBuffer[9] = 0x00;  // PKT_FIELD_1_LENGTH
-    sendBuffer[10] = 0x00;
-    sendBuffer[11] = 0x04;  // PKT_FIELD_1_CONFIG
-    sendBuffer[12] = 0x80;  // PKT_FIELD_1_CRC_CONFIG
-    sendBuffer[13] = 0x00;  // PKT_FIELD_2_LENGTH
-    sendBuffer[14] = 0x00;
-    sendBuffer[15] = 0x00;  // PKT_FIELD_2_CONFIG
-    SendCommand(data(sendBuffer), 16, nullptr, 0);
+    SetProperties(PropertyGroup::pkt,
+                  /*startProperty=*/0x08_b,
+                  Span({
+                      0x60_b,  // PKT_LEN: Infinite receive, big endian (MSB first)
+                      0x00_b,  // PKT_LEN_FIELD_SOURCE
+                      0x00_b,  // PKT_LEN_ADJUST
+                      0x30_b,  // PKT_TX_THRESHOLD: Trigger TX FiFo almost empty interrupt when 0x30
+                               // bytes in FiFo (size 0x40) are empty
+                      0x30_b,  // PKT_RX_THRESHOLD: Trigger RX FiFo almost full interrupt when 0x30
+                               // bytes in FiFo (size 0x40) are full
+                      0x00_b,  // PKT_FIELD_1_LENGTH
+                      0x00_b,
+                      0x04_b,  // PKT_FIELD_1_CONFIG
+                      0x80_b,  // PKT_FIELD_1_CRC_CONFIG
+                      0x00_b,  // PKT_FIELD_2_LENGTH
+                      0x00_b,
+                      0x00_b  // PKT_FIELD_2_CONFIG
+                  }));
 
     // Pkt Length part 2
-    // SetProperties(PropertyGroup::
-    //                   /*startProperty=*/
-    //               Span({
-    sendBuffer[0] = 0x11;
-    sendBuffer[propertyGroupIndex] = 0x12;
-    sendBuffer[nPropertiesIndex] = 0x0C;
-    sendBuffer[startPropertyIndex] = 0x14;
-    sendBuffer[4] = 0x00;  // PKT_FIELD_2_CRC_CONFIG
-    sendBuffer[5] = 0x00;  // PKT_FIELD_3_LENGTH
-    sendBuffer[6] = 0x00;
-    sendBuffer[7] = 0x00;  // PKT_FIELD_3_CONFIG
-    sendBuffer[8] = 0x00;  // PKT_FIELD_3_CRC_CONFIG
-    sendBuffer[9] = 0x00;  // PKT_FIELD_4_LENGTH
-    sendBuffer[10] = 0x00;
-    sendBuffer[11] = 0x00;  // PKT_FIELD_4_CONFIG
-    sendBuffer[12] = 0x00;  // PKT_FIELD_4_CRC_CONFIG
-    sendBuffer[13] = 0x00;  // PKT_FIELD_5_LENGTH
-    sendBuffer[14] = 0x00;
-    sendBuffer[15] = 0x00;  // PKT_FIELD_5_CONFIG
-    SendCommand(data(sendBuffer), 16, nullptr, 0);
+    SetProperties(PropertyGroup::pkt,
+                  /*startProperty=*/0x14_b,
+                  Span({
+                      0x00_b,  // PKT_FIELD_2_CRC_CONFIG
+                      0x00_b,  // PKT_FIELD_3_LENGTH
+                      0x00_b,
+                      0x00_b,  // PKT_FIELD_3_CONFIG
+                      0x00_b,  // PKT_FIELD_3_CRC_CONFIG
+                      0x00_b,  // PKT_FIELD_4_LENGTH
+                      0x00_b,
+                      0x00_b,  // PKT_FIELD_4_CONFIG
+                      0x00_b,  // PKT_FIELD_4_CRC_CONFIG
+                      0x00_b,  // PKT_FIELD_5_LENGTH
+                      0x00_b,
+                      0x00_b  // PKT_FIELD_5_CONFIG
+                  }));
 
     // Pkt Length part 3
-    // SetProperties(PropertyGroup::
-    //                   /*startProperty=*/
-    //               Span({
-    sendBuffer[0] = 0x11;
-    sendBuffer[propertyGroupIndex] = 0x12;
-    sendBuffer[nPropertiesIndex] = 0x0C;
-    sendBuffer[startPropertyIndex] = 0x20;
-    sendBuffer[4] = 0x00;  // PKT_FIELD_5_CRC_CONFIG
-    sendBuffer[5] = 0x00;  // PKT_RX_FIELD_1_LENGTH
-    sendBuffer[6] = 0x00;
-    sendBuffer[7] = 0x00;  // PKT_RX_FIELD_1_CONFIG
-    sendBuffer[8] = 0x00;  // PKT_RX_FIELD_1_CRC_CONFIG
-    sendBuffer[9] = 0x00;  // PKT_RX_FIELD_2_LENGTH
-    sendBuffer[10] = 0x00;
-    sendBuffer[11] = 0x00;  // PKT_RX_FIELD_2_CONFIG
-    sendBuffer[12] = 0x00;  // PKT_RX_FIELD_2_CRC_CONFIG
-    sendBuffer[13] = 0x00;  // PKT_RX_FIELD_3_LENGTH
-    sendBuffer[14] = 0x00;
-    sendBuffer[15] = 0x00;  // PKT_RX_FIELD_3_CONFIG
-    SendCommand(data(sendBuffer), 16, nullptr, 0);
+    SetProperties(PropertyGroup::pkt,
+                  /*startProperty=*/0x20_b,
+                  Span({
+                      0x00_b,  // PKT_FIELD_5_CRC_CONFIG
+                      0x00_b,  // PKT_RX_FIELD_1_LENGTH
+                      0x00_b,
+                      0x00_b,  // PKT_RX_FIELD_1_CONFIG
+                      0x00_b,  // PKT_RX_FIELD_1_CRC_CONFIG
+                      0x00_b,  // PKT_RX_FIELD_2_LENGTH
+                      0x00_b,
+                      0x00_b,  // PKT_RX_FIELD_2_CONFIG
+                      0x00_b,  // PKT_RX_FIELD_2_CRC_CONFIG
+                      0x00_b,  // PKT_RX_FIELD_3_LENGTH
+                      0x00_b,
+                      0x00_b  // PKT_RX_FIELD_3_CONFIG
+                  }));
 
     // Pkt Length part 4
-    // SetProperties(PropertyGroup::
-    //                   /*startProperty=*/
-    //               Span({
-    sendBuffer[0] = 0x11;
-    sendBuffer[propertyGroupIndex] = 0x12;
-    sendBuffer[nPropertiesIndex] = 0x09;
-    sendBuffer[startPropertyIndex] = 0x2C;
-    sendBuffer[4] = 0x00;  // PKT_RX_FIELD_3_CRC_CONFIG
-    sendBuffer[5] = 0x00;  // PKT_RX_FIELD_4_LENGTH
-    sendBuffer[6] = 0x00;
-    sendBuffer[7] = 0x00;  // PKT_RX_FIELD_4_CONFIG
-    sendBuffer[8] = 0x00;  // PKT_RX_FIELD_4_CRC_CONFIG
-    sendBuffer[9] = 0x00;  // PKT_RX_FIELD_5_LENGTH
-    sendBuffer[10] = 0x00;
-    sendBuffer[11] = 0x00;  // PKT_RX_FIELD_5_CONFIG
-    sendBuffer[12] = 0x00;  // PKT_RX_FIELD_5_CRC_CONFIG
-    SendCommand(data(sendBuffer), 13, nullptr, 0);
+    SetProperties(PropertyGroup::pkt,
+                  /*startProperty=*/0x2C_b,
+                  Span({
+                      0x00_b,  // PKT_RX_FIELD_3_CRC_CONFIG
+                      0x00_b,  // PKT_RX_FIELD_4_LENGTH
+                      0x00_b,
+                      0x00_b,  // PKT_RX_FIELD_4_CONFIG
+                      0x00_b,  // PKT_RX_FIELD_4_CRC_CONFIG
+                      0x00_b,  // PKT_RX_FIELD_5_LENGTH
+                      0x00_b,
+                      0x00_b,  // PKT_RX_FIELD_5_CONFIG
+                      0x00_b   // PKT_RX_FIELD_5_CRC_CONFIG
+                  }));
+
+    // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
 
     // RF Modem Mod Type
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     SetTxType(txType);
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x20;
@@ -359,6 +335,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x20;
     sendBuffer[nPropertiesIndex] = 0x08;
@@ -386,6 +364,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x20;
     sendBuffer[nPropertiesIndex] = 0x09;
@@ -414,6 +394,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x20;
     sendBuffer[nPropertiesIndex] = 0x07;
@@ -440,6 +422,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x20;
     sendBuffer[nPropertiesIndex] = 0x01;
@@ -457,6 +441,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x20;
     sendBuffer[nPropertiesIndex] = 0x09;
@@ -479,6 +465,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x20;
     sendBuffer[nPropertiesIndex] = 0x09;
@@ -504,6 +492,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x20;
     sendBuffer[nPropertiesIndex] = 0x01;
@@ -517,6 +507,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x20;
     sendBuffer[nPropertiesIndex] = 0x01;
@@ -528,6 +520,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x20;
     sendBuffer[nPropertiesIndex] = 0x01;
@@ -541,6 +535,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x21;
     sendBuffer[nPropertiesIndex] = 0x0C;
@@ -562,6 +558,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x21;
     sendBuffer[nPropertiesIndex] = 0x0C;
@@ -583,6 +581,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x21;
     sendBuffer[nPropertiesIndex] = 0x0C;
@@ -605,6 +605,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x22;
     sendBuffer[nPropertiesIndex] = 0x04;
@@ -625,6 +627,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x23;
     sendBuffer[nPropertiesIndex] = 0x07;
@@ -643,6 +647,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x30;
     sendBuffer[nPropertiesIndex] = 0x0C;
@@ -665,6 +671,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x40;
     sendBuffer[nPropertiesIndex] = 0x08;
@@ -697,6 +705,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x00;
     sendBuffer[nPropertiesIndex] = 0x01;
@@ -708,6 +718,8 @@ auto Initialize(TxType txType) -> void
     // SetProperties(PropertyGroup::
     //                   /*startProperty=*/
     //               Span({
+
+    //               }));
     sendBuffer[0] = 0x11;
     sendBuffer[propertyGroupIndex] = 0x00;
     sendBuffer[nPropertiesIndex] = 0x01;

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -163,11 +163,11 @@ auto Initialize(TxType txType) -> void
     static constexpr auto preamblePattern = std::array<Byte, 4>{};
     SetProperties(PropertyGroup::preamble,
                   iPreambleTxLength,
-                  Span(FlatArray(preambleTxLength,    // PREAMBLE_TX_LENGTH:
-                                 preambleConfigStd1,  // PREAMBLE_CONFIG_STD_1:
-                                 preambleConfigNstd,  // PREAMBLE_CONFIG_NSTD:
-                                 preambleConfigStd2,  // PREAMBLE_CONFIG_STD_2:
-                                 preambleConfig,      // PREAMBLE_CONFIG:
+                  Span(FlatArray(preambleTxLength,
+                                 preambleConfigStd1,
+                                 preambleConfigNstd,
+                                 preambleConfigStd2,
+                                 preambleConfig,
                                  preamblePattern)));
 
     // Sync word config
@@ -187,412 +187,490 @@ auto Initialize(TxType txType) -> void
     SetProperties(PropertyGroup::sync, iSyncConfig, Span(FlatArray(syncConfig, syncBits)));
 
     // CRC Config
-    SetProperties(PropertyGroup::pkt,
-                  0x00_b,
-                  Span({
-                      0x00_b  // PKT_CRC_CONFIG: No CRC
-                  }));
+    static constexpr auto iPktCrcConfig = 0x00_b;
+    // No CRC
+    static constexpr auto pktCrcConfig = 0x00_b;
+    SetProperties(PropertyGroup::pkt, iPktCrcConfig, Span({pktCrcConfig}));
 
     // Whitening and Packet Parameters
-    SetProperties(PropertyGroup::pkt,
-                  0x05_b,
-                  Span({
-                      0x00_b,  // PKT_WHT_BIT_NUM: Disable whitening
-                      0x01_b   // PKT_CONFIG1: Don't split RX and TX field information (length,
-                               // ...), enable RX packet handler, use normal (2)FSK, no Manchester
-                               // coding, no CRC, data transmission with MSB first.
-                  }));
+    static constexpr auto iPktWhtBitNum = 0x05_b;
+    // Disable whitening
+    static constexpr auto pktWhtBitNum = 0x00_b;
+    // Don't split RX and TX field information (length, ...), enable RX packet handler, use normal
+    // (2)FSK, no Manchester coding, no CRC, data transmission with MSB first.
+    static constexpr auto pktConfig1 = 0x01_b;
+    SetProperties(PropertyGroup::pkt, iPktWhtBitNum, Span({pktWhtBitNum, pktConfig1}));
 
     // Pkt Length part 1
+    static constexpr auto iPktLen = 0x08_b;
+    // Infinite receive, big endian (MSB first)
+    static constexpr auto pktLen = 0x60_b;
+    static constexpr auto pktLenFieldSource = 0x00_b;
+    static constexpr auto pktLenAdjust = 0x00_b;
+    // Trigger TX FiFo almost empty interrupt when 0x30 bytes in FiFo (size 0x40) are empty
+    static constexpr auto pktTxThreshold = 0x30_b;
+    // Trigger RX FiFo almost full interrupt when 0x30 bytes in FiFo (size 0x40) are full
+    static constexpr auto pktRxThreshold = 0x30_b;
+    static constexpr auto pktField1Length = std::array{0x00_b, 0x00_b};
+    static constexpr auto pktField1Config = 0x04_b;
+    static constexpr auto pktField1CrcConfig = 0x80_b;
+    static constexpr auto pktField2Length = std::array{0x00_b, 0x00_b};
+    static constexpr auto pktField2Config = 0x00_b;
     SetProperties(PropertyGroup::pkt,
-                  0x08_b,
-                  Span({
-                      0x60_b,  // PKT_LEN: Infinite receive, big endian (MSB first)
-                      0x00_b,  // PKT_LEN_FIELD_SOURCE
-                      0x00_b,  // PKT_LEN_ADJUST
-                      0x30_b,  // PKT_TX_THRESHOLD: Trigger TX FiFo almost empty interrupt when 0x30
-                               // bytes in FiFo (size 0x40) are empty
-                      0x30_b,  // PKT_RX_THRESHOLD: Trigger RX FiFo almost full interrupt when 0x30
-                               // bytes in FiFo (size 0x40) are full
-                      0x00_b,  // PKT_FIELD_1_LENGTH
-                      0x00_b,
-                      0x04_b,  // PKT_FIELD_1_CONFIG
-                      0x80_b,  // PKT_FIELD_1_CRC_CONFIG
-                      0x00_b,  // PKT_FIELD_2_LENGTH
-                      0x00_b,
-                      0x00_b  // PKT_FIELD_2_CONFIG
-                  }));
+                  iPktLen,
+                  Span(FlatArray(pktLen,
+                                 pktLenFieldSource,
+                                 pktLenAdjust,
+                                 pktTxThreshold,
+                                 pktRxThreshold,
+                                 pktField1Length,
+                                 pktField1Config,
+                                 pktField1CrcConfig,
+                                 pktField2Length,
+                                 pktField2Config)));
 
     // Pkt Length part 2
+    static constexpr auto iPktField2CrcConfig = 0x14_b;
+    static constexpr auto pktField2CrcConfig = 0x00_b;
+    static constexpr auto pktField3Length = std::array{0x00_b, 0x00_b};
+    static constexpr auto pktField3Config = 0x00_b;
+    static constexpr auto pktField3CrcConfig = 0x00_b;
+    static constexpr auto pktField4Length = std::array{0x00_b, 0x00_b};
+    static constexpr auto pktField4Config = 0x00_b;
+    static constexpr auto pktField4CrcConfig = 0x00_b;
+    static constexpr auto pktField5Length = std::array{0x00_b, 0x00_b};
+    static constexpr auto pktField5Config = 0x00_b;
     SetProperties(PropertyGroup::pkt,
-                  0x14_b,
-                  Span({
-                      0x00_b,  // PKT_FIELD_2_CRC_CONFIG
-                      0x00_b,  // PKT_FIELD_3_LENGTH
-                      0x00_b,
-                      0x00_b,  // PKT_FIELD_3_CONFIG
-                      0x00_b,  // PKT_FIELD_3_CRC_CONFIG
-                      0x00_b,  // PKT_FIELD_4_LENGTH
-                      0x00_b,
-                      0x00_b,  // PKT_FIELD_4_CONFIG
-                      0x00_b,  // PKT_FIELD_4_CRC_CONFIG
-                      0x00_b,  // PKT_FIELD_5_LENGTH
-                      0x00_b,
-                      0x00_b  // PKT_FIELD_5_CONFIG
-                  }));
+                  iPktField2CrcConfig,
+                  Span(FlatArray(pktField2CrcConfig,
+                                 pktField3Length,
+                                 pktField3Config,
+                                 pktField3CrcConfig,
+                                 pktField4Length,
+                                 pktField4Config,
+                                 pktField4CrcConfig,
+                                 pktField5Length,
+                                 pktField5Config)));
 
     // Pkt Length part 3
+    static constexpr auto iPktField5CrcConfig = 0x20_b;
+    static constexpr auto pktField5CrcConfig = 0x00_b;
+    static constexpr auto pktRxField1Length = std::array{0x00_b, 0x00_b};
+    static constexpr auto pktRxField1Config = 0x00_b;
+    static constexpr auto pktRxField1CrcConfig = 0x00_b;
+    static constexpr auto pktRxField2Length = std::array{0x00_b, 0x00_b};
+    static constexpr auto pktRxField2Config = 0x00_b;
+    static constexpr auto pktRxField2CrcConfig = 0x00_b;
+    static constexpr auto pktRxField3Length = std::array{0x00_b, 0x00_b};
+    static constexpr auto pktRxField3Config = 0x00_b;
     SetProperties(PropertyGroup::pkt,
-                  0x20_b,
-                  Span({
-                      0x00_b,  // PKT_FIELD_5_CRC_CONFIG
-                      0x00_b,  // PKT_RX_FIELD_1_LENGTH
-                      0x00_b,
-                      0x00_b,  // PKT_RX_FIELD_1_CONFIG
-                      0x00_b,  // PKT_RX_FIELD_1_CRC_CONFIG
-                      0x00_b,  // PKT_RX_FIELD_2_LENGTH
-                      0x00_b,
-                      0x00_b,  // PKT_RX_FIELD_2_CONFIG
-                      0x00_b,  // PKT_RX_FIELD_2_CRC_CONFIG
-                      0x00_b,  // PKT_RX_FIELD_3_LENGTH
-                      0x00_b,
-                      0x00_b  // PKT_RX_FIELD_3_CONFIG
-                  }));
+                  iPktField5CrcConfig,
+                  Span(FlatArray(pktField5CrcConfig,
+                                 pktRxField1Length,
+                                 pktRxField1Config,
+                                 pktRxField1CrcConfig,
+                                 pktRxField2Length,
+                                 pktRxField2Config,
+                                 pktRxField2CrcConfig,
+                                 pktRxField3Length,
+                                 pktRxField3Config)));
 
     // Pkt Length part 4
+    static constexpr auto iPktRxField3CrcConfig = 0x2C_b;
+    static constexpr auto pktRxField3CrcConfig = 0x00_b;
+    static constexpr auto pktRxField4Length = std::array{0x00_b, 0x00_b};
+    static constexpr auto pktRxField4Config = 0x00_b;
+    static constexpr auto pktRxField4CrcConfig = 0x00_b;
+    static constexpr auto pktRxField5Length = std::array{0x00_b, 0x00_b};
+    static constexpr auto pktRxField5Config = 0x00_b;
+    static constexpr auto pktRxField5CrcConfig = 0x00_b;
     SetProperties(PropertyGroup::pkt,
-                  0x2C_b,
-                  Span({
-                      0x00_b,  // PKT_RX_FIELD_3_CRC_CONFIG
-                      0x00_b,  // PKT_RX_FIELD_4_LENGTH
-                      0x00_b,
-                      0x00_b,  // PKT_RX_FIELD_4_CONFIG
-                      0x00_b,  // PKT_RX_FIELD_4_CRC_CONFIG
-                      0x00_b,  // PKT_RX_FIELD_5_LENGTH
-                      0x00_b,
-                      0x00_b,  // PKT_RX_FIELD_5_CONFIG
-                      0x00_b   // PKT_RX_FIELD_5_CRC_CONFIG
-                  }));
+                  iPktRxField3CrcConfig,
+                  Span(FlatArray(pktRxField3CrcConfig,
+                                 pktRxField4Length,
+                                 pktRxField4Config,
+                                 pktRxField4CrcConfig,
+                                 pktRxField5Length,
+                                 pktRxField5Config,
+                                 pktRxField5CrcConfig)));
 
     // RF Modem Mod Type
     SetTxType(txType);
     // SetTxType sets modem properties from 0x00 to 0x05
+    static constexpr auto iModemTxNcoMode = 0x06_b;
+    // TXOSR=x10=0, NCOMOD=F_XTAL/10=2600000=0x027ac40
+    static constexpr auto modemTxNcoMode = std::array{0x00_b, 0x27_b, 0xAC_b, 0x40_b};
+    // (2^19 * outdiv * deviation_Hz)/(N_presc * F_xo) = (2^19 * 8 * 9600/4)/(2 * 26000000) = 194
+    // = 0x0000C2
+    static constexpr auto modemFreqDeviation = std::array{0x00_b, 0x00_b, 0xC2_b};
     SetProperties(
-        PropertyGroup::modem,
-        0x06_b,
-        Span({0x00_b,  // MODEM_TX_NCO_MODE: TXOSR=x10=0, NCOMOD=F_XTAL/10=2600000=0x027ac40
-              0x27_b,
-              0xAC_b,
-              0x40_b,
-              0x00_b,  // MODEM_FREQ_DEVIATION: (2^19 * outdiv * deviation_Hz)/(N_presc *
-                       // F_xo) = (2^19 * 8 * 9600/4)/(2 * 26000000) = 194 = 0x0000C2
-              0x00_b,
-              0xC2_b}));
+        PropertyGroup::modem, iModemTxNcoMode, Span(FlatArray(modemTxNcoMode, modemFreqDeviation)));
 
 
     // RF Modem TX Ramp Delay, Modem MDM Ctrl, Modem IF Ctrl, Modem IF Freq & Modem Decimation
     // Cfg
-    SetProperties(
-        PropertyGroup::modem,
-        0x18_b,
-        Span({
-            0x01_b,  // MODEM_TX_RAMP_DELAY: Ramp Delay 1
-            0x80_b,  // MODEM_MDM_CTRL: Slicer phase source from detector's output
-            0x08_b,  // MODEM_IF_CONTROL: No ETSI mode, fixed IF mode,
-                     // normal IF mode (nonzero IF)
-            0x03_b,  // MODEM_IF_FREQ: IF = (2^19 * outdiv * IF_Freq_Hz)/(npresc * freq_xo) =
-                     // (2^19 * 8 * xxx)/(2 * 26000000) = 0x03C000 (default value)
-                     // TODO: Is it important what we chose here?
-            0xC0_b,
-            0x00_b,
-            0x70_b,  // MODEM_DECIMATION_CFG1: Decimation NDEC0 = 0, NDEC1 = decimation
-                     // by 8, NDEC2 = decimation by 2
-            0x20_b   // MODEM_DECIMATION_CFG0: Normal decimate-by-8 filter gain,
-                     // don't bypass the decimate-by-2 polyphase filter, bypass the decimate-by-3
-                     // polyphase filter, enable
-                     // droop compensation, channel selection filter in normal mode (27 tap filter)
-        }));
+    static constexpr auto iModemTxRampDelay = 0x18_b;
+    // Ramp Delay 1
+    static constexpr auto modemTxRampDelay = 0x01_b;
+    // Slicer phase source from detector's output
+    static constexpr auto modemMdmCtrl = 0x80_b;
+    // No ETSI mode, fixed IF mode, normal IF mode (nonzero IF)
+    static constexpr auto modemIfControl = 0x08_b;
+    // IF = (2^19 * outdiv * IF_Freq_Hz)/(npresc * freq_xo) = (2^19 * 8 * xxx)/(2 * 26000000)
+    // = 0x03C000 (default value)
+    // TODO: Is it important what we chose here?
+    static constexpr auto modemIfFreq = std::array{0x03_b, 0xC0_b, 0x00_b};
+    // Decimation NDEC0 = 0, NDEC1 = decimation by 8, NDEC2 = decimation by 2
+    static constexpr auto modemDecimationCfg1 = 0x70_b;
+    // Normal decimate-by-8 filter gain, don't bypass the decimate-by-2 polyphase filter, bypass the
+    // decimate-by-3 polyphase filter, enable droop compensation, channel selection filter in normal
+    // mode (27 tap filter)
+    static constexpr auto modemDecimationCfg0 = 0x20_b;
+    SetProperties(PropertyGroup::modem,
+                  iModemTxRampDelay,
+                  Span(FlatArray(modemTxRampDelay,
+                                 modemMdmCtrl,
+                                 modemIfControl,
+                                 modemIfFreq,
+                                 modemDecimationCfg1,
+                                 modemDecimationCfg0)));
 
     // RF Modem BCR Oversampling Rate, Modem BCR NCO Offset, Modem BCR Gain, Modem BCR Gear &
     // Modem BCR Misc
     // TODO: What values to use here?
+    static constexpr auto iModemBcrOsr = 0x22_b;
+    // RX symbol oversampling rate of 0x30D/8 = 781/8
+    // = 97.625 (According to the datasheet usual values are in the range
+    // of 8 to 12 where this value seems to be odd?)
+    static constexpr auto modemBcrOsr = std::array{0x03_b, 0x0D_b};
+    // BCR NCO offset of 0x00A7C6/64 = 42950/64 = 671.09375
+    static constexpr auto modemBcrNcoOffset = std::array{0x00_b, 0xA7_b, 0xC6_b};
+    // BCR gain 0x054 = 84
+    static constexpr auto modemBcrGain = std::array{0x00_b, 0x54_b};
+    // BCR loop gear control. CRSLOW=2, CRFAST=0
+    static constexpr auto modemBcrGear = 0x02_b;
+    // Stop NCO for one sample clock in BCR mid-point phase
+    // sampling condition to escape, disable NCO resetting in case of
+    // mid-point phase sampling condition, don't double BCR loop gain, BCR
+    // NCO compensation is sampled upon detection of the preamble end,
+    // disable NCO frequency compensation, bypass compensation term feedback
+    // to slicer, bypass compensation term feedback to BCR tracking loop
+    static constexpr auto modemBcrMisc1 = 0xC2_b;
     SetProperties(
         PropertyGroup::modem,
-        0x22_b,
-        Span({
-            0x03_b,  // MODEM_BCR_OSR: RX symbol oversampling rate of 0x30D/8 = 781/8
-                     // = 97.625 (According to the datasheet usual values are in the range
-                     // of 8 to 12 where this value seems to be odd?)
-            0x0D_b,
-            0x00_b,  // MODEM_BCR_NCO_OFFSET: BCR NCO offset of
-                     // 0x00A7C6/64 = 42950/64 = 671.09375
-            0xA7_b,
-            0xC6_b,
-            0x00_b,  // MODEM_BCR_GAIN: BCR gain 0x054 = 84
-            0x54_b,
-            0x02_b,  // MODEM_BCR_GEAR: BCR loop gear control. CRSLOW=2, CRFAST=0
-            0xC2_b   // MODEM_BCR_MISC1: Stop NCO for one sample clock in BCR mid-point phase
-                     // sampling condition to escape, disable NCO resetting in case of
-                     // mid-point phase sampling condition, don't double BCR loop gain, BCR
-                     // NCO compensation is sampled upon detection of the preamble end,
-                     // disable NCO frequency compensation, bypass compensation term feedback
-                     // to slicer, bypass compensation term feedback to BCR tracking loop
-        }));
+        iModemBcrOsr,
+        Span(FlatArray(modemBcrOsr, modemBcrNcoOffset, modemBcrGain, modemBcrGear, modemBcrMisc1)));
 
     // RF Modem AFC Gear, Modem AFC Wait, Modem AFC Gain, Modem AFC Limiter & Modem AFC Misc
     // TODO: What values to use here?
+    static constexpr auto iModemAfcGear = 0x2C_b;
+    // AFC_SLOW gain 4, AFC_FAST gain 0, Switch gear after detection of preamble
+    static constexpr auto modemAfcGear = 0x04_b;
+    // LGWAIT = 6, SHWAIT = 3
+    static constexpr auto modemAfcWait = 0x36_b;
+    // AFC loop gain = 0x003, don't half the loop gain, disable adaptive RX bandwidth, enable
+    // frequency error estimation
+    static constexpr auto modemAfcGain = std::array{0x80_b, 0x03_b};
+    // 0x30AF
+    static constexpr auto modemAfcLimiter = std::array{0x30_b, 0xAF_b};
+    // Expected freq error is less then 12*symbol rate, AFC
+    // correction of PLL will be frozen if a consecutive string of 1s or 0s that
+    // exceed the search period is encountered, don't switch clock source for
+    // frequency estimator, don't freeze AFC at preamble end, AFC correction uses
+    // freq estimation by moving average or minmax detector in async demod,disable
+    // AFC value feedback to PLL, freeze AFC after gear switching
+    static constexpr auto modemAfcMisc = 0x80_b;
     SetProperties(
         PropertyGroup::modem,
-        0x2C_b,
-        Span({
-            0x04_b,  // MODEM_AFC_GEAR: AFC_SLOW gain 4, AFC_FAST gain 0, Switch gear
-                     // after detection of preamble
-            0x36_b,  // MODEM_AFC_WAIT: LGWAIT = 6, SHWAIT = 3
-            0x80_b,  // MODEM_AFC_GAIN: AFC loop gain = 0x003, don't half the loop gain,
-                     // disable adaptive RX bandwidth, enable frequency error estimation
-            0x03_b,
-            0x30_b,  // MODEM_AFC_LIMITER: 0x30AF
-            0xAF_b,
-            0x80_b  // MODEM_AFC_MISC: Expected freq error is less then 12*symbol rate, AFC
-                    // correction of PLL will be frozen if a consecutive string of 1s or 0s that
-                    // exceed the search period is encountered, don't switch clock source for
-                    // frequency estimator, don't freeze AFC at preamble end, AFC correction uses
-                    // freq estimation by moving average or minmax detector in async demod,disable
-                    // AFC value feedback to PLL, freeze AFC after gear switching
-        }));
+        iModemAfcGear,
+        Span(FlatArray(modemAfcGear, modemAfcWait, modemAfcGain, modemAfcLimiter, modemAfcMisc)));
 
     // RF Modem AGC Control
     // TODO: What values to use here?
-    SetProperties(
-        PropertyGroup::modem,
-        0x35_b,
-        Span({
-            0xE2_b  // MODEM_AGC_CONTROL: reset peak detectors only on change of gain
-                    // indicated by peak detector output, reduce ADC gain when AGC gain is at
-                    // minimum, normal AGC speed, don't increase AGC gain during signal
-                    // reductions in ant diversity mode, always perform gain decreases in 3dB
-                    // steps instead of 6dB steps, AGC is enabled over whole packet length
-        }));
+    static constexpr auto iModemAgcControl = 0x35_b;
+    // Reset peak detectors only on change of gain
+    // indicated by peak detector output, reduce ADC gain when AGC gain is at
+    // minimum, normal AGC speed, don't increase AGC gain during signal
+    // reductions in ant diversity mode, always perform gain decreases in 3dB
+    // steps instead of 6dB steps, AGC is enabled over whole packet length
+    static constexpr auto modemAgcControl = 0xE2_b;
+    SetProperties(PropertyGroup::modem, iModemAgcControl, Span({modemAgcControl}));
 
     // RF Modem AGC Window Size, AGC RF Peak Detector Decay, AGC IF Peak Detector Decay, 4FSK
     // Gain, 4FSK Slicer Threshold, 4FSK SYmbol Mapping Code, OOK Attack/Decay Times
     // TODO: What values to use here?
+    static constexpr auto iModemAgcWindowSize = 0x38_b;
+    // AGC gain settling window size = 1, AGC signal level measurement window = 1
+    static constexpr auto modemAgcWindowSize = 0x11_b;
+    // RF peak detector decay time = 0xAB = 171
+    static constexpr auto modemAgcRfpdDecay = 0xAB_b;
+    // IF peak detector decay time = 0xAB = 171
+    static constexpr auto modemAgcIfpdDecay = 0xAB_b;
+    // 4FSK Gain1 = 0, Normal second phase compensation factor
+    static constexpr auto modemFsk4Gain1 = 0x00_b;
+    // 4FSK Gain0 = 2, disable 2FSK phase compensation
+    static constexpr auto modemFsk4Gain0 = 0x02_b;
+    // 4FSK slicer threshold = 0xFFFF
+    static constexpr auto modemFsk4Th = std::array{0xFF_b, 0xFF_b};
+    // 4FSK symbol map 0 (`00 `01 `11 `10)
+    static constexpr auto modemFsk4Map = 0x00_b;
+    // OOK decay = 11, OOK attack = 2
+    static constexpr auto modemOokPdtc = 0x2B_b;
     SetProperties(PropertyGroup::modem,
-                  0x38_b,
-                  Span({
-                      0x11_b,  // MODEM_AGC_WINDOW_SIZE: AGC gain settling window size = 1, AGC
-                               // signal level measurement window = 1
-                      0xAB_b,  // MODEM_AGC_RFPD_DECAY: RF peak detector decay time = 0xAB = 171
-                      0xAB_b,  // MODEM_AGC_IFPD_DECAY: IF peak detector decay time = 0xAB = 171
-                      0x00_b,  // MODEM_FSK4_GAIN1: 4FSK Gain1 = 0,
-                               // Normal second phase compensation factor
-                      0x02_b,  // MODEM_FSK4_GAIN0: 4FSK Gain0 = 2, disable 2FSK phase compensation
-                      0xFF_b,  // MODEM_FSK4_TH: 4FSK slicer threshold = 0xFFFF
-                      0xFF_b,
-                      0x00_b,  // MODEM_FSK4_MAP: 4FSK symbol map 0 (`00 `01 `11 `10)
-                      0x2B_b   // MODEM_OOK_PDTC: OOK decay = 11, OOK attack = 2
-                  }));
+                  iModemAgcWindowSize,
+                  Span(FlatArray(modemAgcWindowSize,
+                                 modemAgcRfpdDecay,
+                                 modemAgcIfpdDecay,
+                                 modemFsk4Gain1,
+                                 modemFsk4Gain0,
+                                 modemFsk4Th,
+                                 modemFsk4Map,
+                                 modemOokPdtc)));
 
     // RF Modem OOK Control, OOK Misc, RAW Search, RAW Control, RAW Eye, Antenna Diversity Mode,
     // Antenna Diversity Control, RSSI Threshold
+    static constexpr auto iModemOokCnt1 = 0x42_b;
+    // OOK Squelch off, OOK slicer output de-glitching by bit
+    // clock, raw output is synced to clock, MA_FREQUDOWN=0, AGC and OOK movign
+    // average detector threshold will be frozen after preamble detection,
+    // S2P_MAP=2
+    static constexpr auto modemOokCnt1 = 0xA4_b;
+    // OOK uses moving average detector, OOK peak detector
+    // discharge does not affect decay rate, disable OOK squelch, always
+    // discharge peak detector, normal moving average window
+    static constexpr auto modemOokMisc = 0x02_b;
+    static constexpr auto modemRawControl = 0x83_b;
+    // RAW eye open detector threshold
+    static constexpr auto modemRawEye = std::array{0x00_b, 0xAD_b};
+    // Antenna diversity mode
+    static constexpr auto modemAntDivMode = 0x01_b;
+    // Antenna diversity control
+    static constexpr auto modemAntDivControl = 0x80_b;
+    // Threshold for clear channel assessment and RSSI interrupt generation
+    static constexpr auto modemRssiThresh = 0xFF_b;
     SetProperties(
         PropertyGroup::modem,
-        0x42_b,
-        Span({
-            0xA4_b,  // MODEM_OOK_CNT1: OOK Squelch off, OOK slicer output de-glitching by bit
-                     // clock, raw output is synced to clock, MA_FREQUDOWN=0, AGC and OOK movign
-                     // average detector threshold will be frozen after preamble detection,
-                     // S2P_MAP=2
-            0x02_b,  // MODEM_OOK_MISC: OOK uses moving average detector, OOK peak detector
-                     // discharge does not affect decay rate, disable OOK squelch, always
-                     // discharge peak detector, normal moving average window
-            0xD6_b,  // ??
-            0x83_b,  // MODEM_RAW_CONTROL
-            0x00_b,  // MODEM_RAW_EYE: RAW eye open detector threshold
-            0xAD_b,
-            0x01_b,  // MODEM_ANT_DIV_MODE: Antenna diversity mode
-            0x80_b,  // MODEM_ANT_DIV_CONTROL: Antenna diversity control
-            0xFF_b   // MODEM_RSSI_THRESH: Threshold for clear channel assessment and
-                     // RSSI interrupt generation
-        }));
+        iModemOokCnt1,
+        Span(FlatArray(
+            modemOokCnt1,
+            modemOokMisc,
+            0xD6_b,  // TODO: index 0x44 is not described in the API, what does this value do?
+            modemRawControl,
+            modemRawEye,
+            modemAntDivMode,
+            modemAntDivControl,
+            modemRssiThresh)));
 
     // RF Modem RSSI Control
-    SetProperties(PropertyGroup::modem,
-                  0x4C_b,
-                  Span({
-                      0x00_b  // MODEM_RSSI_CONTROL: Disable RSSI latch, RSSI value is avg over
-                              // last 4*Tb bit periods, disable RSSI threshold check after latch
-                  }));
+    static constexpr auto iModemRssiControl = 0x4C_b;
+    // Disable RSSI latch, RSSI value is avg over last 4*Tb bit periods, disable RSSI threshold
+    // check after latch
+    static constexpr auto modemRssiControl = 0x00_b;
+    SetProperties(PropertyGroup::modem, iModemRssiControl, Span({modemRssiControl}));
 
     // RF Modem RSSI Compensation
     // TODO: Measure this
-    SetProperties(PropertyGroup::modem,
-                  0x4E_b,
-                  Span({
-                      0x40_b  // MODEM_RSSI_COMP: Compensation/offset of measured RSSI value
-                  }));
+    static constexpr auto iModemRssiComp = 0x4E_b;
+    // Compensation/offset of measured RSSI value
+    static constexpr auto modemRssiComp = 0x40_b;
+    SetProperties(PropertyGroup::modem, iModemRssiComp, Span({modemRssiComp}));
 
     // RF Modem Clock generation Band
-    SetProperties(PropertyGroup::modem,
-                  0x51_b,
-                  Span({
-                      0x0A_b  // MODEM_CLKGEN_BAND: Band = FVCO_DIV_8, high performance mode fixed
-                              // prescaler div2, force recalibration
-                  }));
+    static constexpr auto iModemClkgenBand = 0x51_b;
+    // Band = FVCO_DIV_8, high performance mode fixed prescaler div2, force recalibration
+    static constexpr auto modemClkgenBand = 0x0A_b;
+    SetProperties(PropertyGroup::modem, iModemClkgenBand, Span({modemClkgenBand}));
 
     // RX Filter Coefficients
     // TODO: What values to use here?
-    SetProperties(PropertyGroup::modemChflt,
-                  0x00_b,
-                  Span({
-                      0xFF_b,  // RX1_CHFLT_COE13[7:0]
-                      0xC4_b,  // RX1_CHFLT_COE12[7:0]
-                      0x30_b,  // RX1_CHFLT_COE11[7:0]
-                      0x7F_b,  // RX1_CHFLT_COE10[7:0]
-                      0xF5_b,  // RX1_CHFLT_COE9[7:0]
-                      0xB5_b,  // RX1_CHFLT_COE8[7:0]
-                      0xB8_b,  // RX1_CHFLT_COE7[7:0]
-                      0xDE_b,  // RX1_CHFLT_COE6[7:0]
-                      0x05_b,  // RX1_CHFLT_COE5[7:0]
-                      0x17_b,  // RX1_CHFLT_COE4[7:0]
-                      0x16_b,  // RX1_CHFLT_COE3[7:0]
-                      0x0C_b   // RX1_CHFLT_COE2[7:0]
-                  }));
-
+    // Block 1
+    static constexpr auto iRxFilterCoefficientsBlock1 = 0x00_b;
+    static constexpr auto rxFilterCoefficientsBlock1 = std::array{
+        0xFF_b,  // RX1_CHFLT_COE13[7:0]
+        0xC4_b,  // RX1_CHFLT_COE12[7:0]
+        0x30_b,  // RX1_CHFLT_COE11[7:0]
+        0x7F_b,  // RX1_CHFLT_COE10[7:0]
+        0xF5_b,  // RX1_CHFLT_COE9[7:0]
+        0xB5_b,  // RX1_CHFLT_COE8[7:0]
+        0xB8_b,  // RX1_CHFLT_COE7[7:0]
+        0xDE_b,  // RX1_CHFLT_COE6[7:0]
+        0x05_b,  // RX1_CHFLT_COE5[7:0]
+        0x17_b,  // RX1_CHFLT_COE4[7:0]
+        0x16_b,  // RX1_CHFLT_COE3[7:0]
+        0x0C_b   // RX1_CHFLT_COE2[7:0]
+    };
     SetProperties(
-        PropertyGroup::modemChflt,
-        0x0C_b,
-        Span({
-            0x03_b,  // RX1_CHFLT_COE1[7:0]
-            0x00_b,  // RX1_CHFLT_COE0[7:0]
-            0x15_b,  // RX1_CHFLT_COE10[9:8]  | RX1_CHFLT_COE11[9:8]  | RX1_CHFLT_COE12[9:8]  |
-                     // RX1_CHFLT_COE13[9:8]
-            0xFF_b,  // RX1_CHFLT_COE6[9:8]   | RX1_CHFLT_COE7[9:8]   | RX1_CHFLT_COE8[9:8]   |
-                     // RX1_CHFLT_COE9[9:8]
-            0x00_b,  // RX1_CHFLT_COE2[9:8]   | RX1_CHFLT_COE3[9:8]   | RX1_CHFLT_COE4[9:8]   |
-                     // RX1_CHFLT_COE5[9:8]
-            0x00_b,  // 0 | 0 | 0 | 0         | RX1_CHFLT_COE0[9:8]   | RX1_CHFLT_COE1[9:8]
-            0xFF_b,  // RX2_CHFLT_COE13[7:0]
-            0xC4_b,  // RX2_CHFLT_COE12[7:0]
-            0x30_b,  // RX2_CHFLT_COE11[7:0]
-            0x7F_b,  // RX2_CHFLT_COE10[7:0]
-            0xF5_b,  // RX2_CHFLT_COE9[7:0]
-            0xB5_b   // RX2_CHFLT_COE8[7:0]
-        }));
+        PropertyGroup::modemChflt, iRxFilterCoefficientsBlock1, Span(rxFilterCoefficientsBlock1));
 
+    // Block 2
+    static constexpr auto iRxFilterCoefficientsBlock2 = 0x0C_b;
+    static constexpr auto rxFilterCoefficientsBlock2 = std::array{
+        0x03_b,  // RX1_CHFLT_COE1[7:0]
+        0x00_b,  // RX1_CHFLT_COE0[7:0]
+        0x15_b,  // RX1_CHFLT_COE10[9:8]  | RX1_CHFLT_COE11[9:8]  | RX1_CHFLT_COE12[9:8]  |
+                 // RX1_CHFLT_COE13[9:8]
+        0xFF_b,  // RX1_CHFLT_COE6[9:8]   | RX1_CHFLT_COE7[9:8]   | RX1_CHFLT_COE8[9:8]   |
+                 // RX1_CHFLT_COE9[9:8]
+        0x00_b,  // RX1_CHFLT_COE2[9:8]   | RX1_CHFLT_COE3[9:8]   | RX1_CHFLT_COE4[9:8]   |
+                 // RX1_CHFLT_COE5[9:8]
+        0x00_b,  // 0 | 0 | 0 | 0         | RX1_CHFLT_COE0[9:8]   | RX1_CHFLT_COE1[9:8]
+        0xFF_b,  // RX2_CHFLT_COE13[7:0]
+        0xC4_b,  // RX2_CHFLT_COE12[7:0]
+        0x30_b,  // RX2_CHFLT_COE11[7:0]
+        0x7F_b,  // RX2_CHFLT_COE10[7:0]
+        0xF5_b,  // RX2_CHFLT_COE9[7:0]
+        0xB5_b   // RX2_CHFLT_COE8[7:0]
+    };
     SetProperties(
-        PropertyGroup::modemChflt,
-        0x18_b,
-        Span({
-            0xB8_b,  // RX2_CHFLT_COE7[7:0]
-            0xDE_b,  // RX2_CHFLT_COE6[7:0]
-            0x05_b,  // RX2_CHFLT_COE5[7:0]
-            0x17_b,  // RX2_CHFLT_COE4[7:0]
-            0x16_b,  // RX2_CHFLT_COE3[7:0]
-            0x0C_b,  // RX2_CHFLT_COE2[7:0]
-            0x03_b,  // RX2_CHFLT_COE1[7:0]
-            0x00_b,  // RX2_CHFLT_COE0[7:0]
-            0x15_b,  // RX2_CHFLT_COE10[9:8]  | RX2_CHFLT_COE11[9:8]  |
-                     // RX2_CHFLT_COE12[9:8]  | RX2_CHFLT_COE13[9:8]
-            0xFF_b,  // RX2_CHFLT_COE6[9:8]   | RX2_CHFLT_COE7[9:8]   | RX2_CHFLT_COE8[9:8] |
-                     // RX2_CHFLT_COE9[9:8]
-            0x00_b,  // RX2_CHFLT_COE2[9:8]   | RX2_CHFLT_COE3[9:8]   | RX2_CHFLT_COE4[9:8] |
-                     // RX2_CHFLT_COE5[9:8]
-            0x00_b   // 0 | 0 | 0 | 0         | RX2_CHFLT_COE0[9:8]   | RX2_CHFLT_COE1[9:8] |
-        }));
+        PropertyGroup::modemChflt, iRxFilterCoefficientsBlock2, Span(rxFilterCoefficientsBlock2));
+
+    // Block 3
+    static constexpr auto iRxFilterCoefficientsBlock3 = 0x18_b;
+    static constexpr auto rxFilterCoefficientsBlock3 = std::array{
+        0xB8_b,  // RX2_CHFLT_COE7[7:0]
+        0xDE_b,  // RX2_CHFLT_COE6[7:0]
+        0x05_b,  // RX2_CHFLT_COE5[7:0]
+        0x17_b,  // RX2_CHFLT_COE4[7:0]
+        0x16_b,  // RX2_CHFLT_COE3[7:0]
+        0x0C_b,  // RX2_CHFLT_COE2[7:0]
+        0x03_b,  // RX2_CHFLT_COE1[7:0]
+        0x00_b,  // RX2_CHFLT_COE0[7:0]
+        0x15_b,  // RX2_CHFLT_COE10[9:8]  | RX2_CHFLT_COE11[9:8]  |
+                 // RX2_CHFLT_COE12[9:8]  | RX2_CHFLT_COE13[9:8]
+        0xFF_b,  // RX2_CHFLT_COE6[9:8]   | RX2_CHFLT_COE7[9:8]   | RX2_CHFLT_COE8[9:8] |
+                 // RX2_CHFLT_COE9[9:8]
+        0x00_b,  // RX2_CHFLT_COE2[9:8]   | RX2_CHFLT_COE3[9:8]   | RX2_CHFLT_COE4[9:8] |
+                 // RX2_CHFLT_COE5[9:8]
+        0x00_b   // 0 | 0 | 0 | 0         | RX2_CHFLT_COE0[9:8]   | RX2_CHFLT_COE1[9:8] |
+    };
+    SetProperties(
+        PropertyGroup::modemChflt, iRxFilterCoefficientsBlock3, Span(rxFilterCoefficientsBlock3));
 
     // RF PA Mode
-    SetProperties(PropertyGroup::pa,
-                  0x00_b,
-                  Span({
-                      0x08_b,  // PA_MODE: PA switching amp mode, PA_SEL = HP_COARSE, disable power
-                               // sequencing, disable external TX ramp signal
-                      0x18_b,  // PA_PWR_LVL: Enabled PA fingers (sets output power but not
-                               // linearly; 10µA bias current per enabled finger, complementary
-                               // drive signal with 50% duty cycle)
-                      0x00_b,  // PA_BIAS_CLKDUTY
-                      0x91_b   // PA_TC: Ramping time constant = 0x1B (~10us to full-0.5dB), FSK
-                               // modulation delay 10µs
-                  }));
+    static constexpr auto iPaMode = 0x00_b;
+    // PA switching amp mode, PA_SEL = HP_COARSE, disable power sequencing, disable external TX ramp
+    // signal
+    static constexpr auto paMode = 0x08_b;
+    // Enabled PA fingers (sets output power but not linearly; 10µA bias current per enabled finger,
+    // complementary drive signal with 50% duty cycle)
+    static constexpr auto paPwrLvl = 0x18_b;
+    static constexpr auto paBiasClkduty = 0x00_b;
+    // Ramping time constant = 0x1B (~10us to full-0.5dB), FSK modulation delay 10µs
+    static constexpr auto paTc = 0x91_b;
+    SetProperties(PropertyGroup::pa, iPaMode, Span({paMode, paPwrLvl, paBiasClkduty, paTc}));
 
     // RF Synth Feed Forward Charge Pump Current, Integrated Charge Pump Current, VCO Gain
     // Scaling Factor, FF Loop Filter Values
     // TODO: What values to use here?
+    static constexpr auto iSynthPfdcpCpff = 0x00_b;
+    // FF charge pump current = 60µA
+    static constexpr auto synthPfdcpCpff = 0x2C_b;
+    // SYNTH_PFDCP_CPINT: Int charge pump current = 30µA
+    static constexpr auto synthPfdcpCpint = 0x0E_b;
+    // SYNTH_VCO_KV: Set VCO scaling factor to maximum value, set tuning
+    // varactor gain to maximum value
+    static constexpr auto synthVcoKv = 0x0B_b;
+    // SYNTH_LPFILT3: R2 value 90kOhm
+    static constexpr auto synthLpfilt3 = 0x04_b;
+    // SYNTH_LPFILT2: C2 value 11.25pF
+    static constexpr auto synthLpfilt2 = 0x0C_b;
+    // SYNTH_LPFILT1: C3 value 12pF, C1 offset 0pF, C1 value 7.21pF
+    static constexpr auto synthLpfilt1 = 0x73_b;
+    // SYNTH_LPFILT0: FF amp bias current 100µA
+    static constexpr auto synthLpfilt0 = 0x03_b;
     SetProperties(PropertyGroup::synth,
-                  0x00_b,
-                  Span({
-                      0x2C_b,  // SYNTH_PFDCP_CPFF: FF charge pump current = 60µA
-                      0x0E_b,  // SYNTH_PFDCP_CPINT: Int charge pump current = 30µA
-                      0x0B_b,  // SYNTH_VCO_KV: Set VCO scaling factor to maximum value, set tuning
-                               // varactor gain to maximum value
-                      0x04_b,  // SYNTH_LPFILT3: R2 value 90kOhm
-                      0x0C_b,  // SYNTH_LPFILT2: C2 value 11.25pF
-                      0x73_b,  // SYNTH_LPFILT1: C3 value 12pF, C1 offset 0pF, C1 value 7.21pF
-                      0x03_b   // SYNTH_LPFILT0: FF amp bias current 100µA
-                  }));
+                  iSynthPfdcpCpff,
+                  Span({synthPfdcpCpff,
+                        synthPfdcpCpint,
+                        synthVcoKv,
+                        synthLpfilt3,
+                        synthLpfilt2,
+                        synthLpfilt1,
+                        synthLpfilt0}));
 
     // RF Match Mask
+    static constexpr auto iMatchValue1 = 0x00_b;
+    static constexpr auto matchValue1 = 0x00_b;
+    static constexpr auto matchMask1 = 0x00_b;
+    static constexpr auto matchCtrl1 = 0x00_b;
+    static constexpr auto matchValue2 = 0x00_b;
+    static constexpr auto matchMask2 = 0x00_b;
+    static constexpr auto matchCtrl2 = 0x00_b;
+    static constexpr auto matchValue3 = 0x00_b;
+    static constexpr auto matchMask3 = 0x00_b;
+    static constexpr auto matchCtrl3 = 0x00_b;
+    static constexpr auto matchValue4 = 0x00_b;
+    static constexpr auto matchMask4 = 0x00_b;
+    static constexpr auto matchCtrl4 = 0x00_b;
     SetProperties(PropertyGroup::match,
-                  0x00_b,
-                  Span({
-                      0x00_b,  // MATCH_VALUE_1
-                      0x00_b,  // MATCH_MASK_1
-                      0x00_b,  // MATCH_CTRL_1
-                      0x00_b,  // MATCH_VALUE_2
-                      0x00_b,  // MATCH_MASK_2
-                      0x00_b,  // MATCH_CTRL_2
-                      0x00_b,  // MATCH_VALUE_3
-                      0x00_b,  // MATCH_MASK_3
-                      0x00_b,  // MATCH_CTRL_3
-                      0x00_b,  // MATCH_VALUE_4
-                      0x00_b,  // MATCH_MASK_4
-                      0x00_b   // MATCH_CTRL_4
-                  }));
+                  iMatchValue1,
+                  Span({matchValue1,
+                        matchMask1,
+                        matchCtrl1,
+                        matchValue2,
+                        matchMask2,
+                        matchCtrl2,
+                        matchValue3,
+                        matchMask3,
+                        matchCtrl3,
+                        matchValue4,
+                        matchMask4,
+                        matchCtrl4}));
 
     // Frequency Control
-    SetProperties(
-        PropertyGroup::freqControl,
-        0x00_b,
-        Span({
-            0x41_b,  // FREQ_CONTROL_INTE: FC_inte = 0x41
-            0x0E_b,  // FREQ_CONTROL_FRAC: FC_frac. 0xD89D9 = 433.5, 0xEC4EC = 434.5
-            0xC4_b,
-            0xEC_b,
-            // N_presc = 2, outdiv = 8, F_xo = 26MHz
-            // RF_channel_Hz = (FC_inte + FC_frac/2^19)*((N_presc*F_xo)/outdiv) = 433.5000048MHz MHz
-            0x44_b,  // FREQ_CONTROL_CHANNEL_STEP_SIZE: Channel step size = 0x4444
-            0x44_b,
-            0x20_b,  // FREQ_CONTROL_W_SIZE: Window gating period (in number of crystal clock
-                     // cycles) = 32
-            0xFE_b   // FREQ_CONTROL_VCOCNT_RX_ADJ: Adjust target mode for VCO
-                     // calibration in RX mode = 0xFE int8_t
-        }));
+    static constexpr auto iFreqControlInte = 0x00_b;
+    // FC_inte = 0x41
+    static constexpr auto freqControlInte = 0x41_b;
+    // FC_frac. 0xD89D9 = 433.5, 0xEC4EC = 434.5
+    // N_presc = 2, outdiv = 8, F_xo = 26MHz
+    // RF_channel_Hz = (FC_inte + FC_frac/2^19)*((N_presc*F_xo)/outdiv) = 433.5000048MHz MHz
+    static constexpr auto freqControlFrac = std::array{0x0E_b, 0xC4_b, 0xEC_b};
+    // Channel step size = 0x4444
+    static constexpr auto freqControlChannelStepSize = std::array{0x44_b, 0x44_b};
+    // Window gating period (in number of crystal clock cycles) = 32
+    static constexpr auto freqControlWSize = 0x20_b;
+    // Adjust target mode for VCO calibration in RX mode = 0xFE int8_t
+    static constexpr auto freqControlVcontRxAdj = 0xFE_b;
+
+    SetProperties(PropertyGroup::freqControl,
+                  iFreqControlInte,
+                  Span(FlatArray(freqControlInte,
+                                 freqControlFrac,
+                                 freqControlChannelStepSize,
+                                 freqControlWSize,
+                                 freqControlVcontRxAdj)));
 
     // Set RF4463 Module Antenna Switch
-    SendCommand(Span({
-        cmdGpioPinCfg,
-        0x00_b,  // Don't change GPIO0 setting
-        0x00_b,  // Don't change GPIO1 setting
-        0x21_b,  // GPIO2 is active in RX state
-        0x20_b,  // GPIO3 is active in TX state
-        0x27_b,  // NIRQ is still used as NIRQ
-        0x0B_b   // SDO is still used as SDO
-    }));
+    // Don't change
+    static constexpr auto gpio0Config = 0x00_b;
+    // Don't change
+    static constexpr auto gpio1Config = 0x00_b;
+    // GPIO2 active in RX state
+    static constexpr auto gpio2Config = 0x21_b;
+    // GPIO3 active in TX state
+    static constexpr auto gpio3Config = 0x20_b;
+    // NIRQ is still used as NIRQ
+    static constexpr auto nirqConfig = 0x27_b;
+    // SDO is still used as SDO
+    static constexpr auto sdoConfig = 0x0B_b;
+    SendCommand(Span({cmdGpioPinCfg,
+                      gpio0Config,
+                      gpio1Config,
+                      gpio2Config,
+                      gpio3Config,
+                      nirqConfig,
+                      sdoConfig}));
 
     // Frequency Adjust (stolen from Arduino demo code)
-    SetProperties(PropertyGroup::global,
-                  0x00_b,
-                  Span({
-                      0x62_b  // GLOBAL_XO_TUNE
-                  }));
+    static constexpr auto globalXoTuneUpdated = 0x62_b;
+    SetProperties(PropertyGroup::global, iGlobalXoTune, Span({globalXoTuneUpdated}));
 
     // Change sequencer mode to guaranteed
-    // TODO: Why?
-    SetProperties(PropertyGroup::global,
-                  0x03_b,
-                  Span({
-                      0x40_b  // GLOBAL_CONFIG: Split FIFO and guaranteed sequencer mode
-                  }));
+    // TODO: Why? And figure out name for new global config constexpr so it does not clash with
+    // previous one
+    // Split FIFO and guaranteed sequencer mode
+    static constexpr auto globalConfigUpdated = 0x40_b;
+    SetProperties(PropertyGroup::global, iGlobalConfig, Span({globalConfigUpdated}));
 
     paEnablePin.Direction(hal::PinDirection::out);
     paEnablePin.Set();

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -675,7 +675,7 @@ auto InitializeGpioAndSpi() -> void
     AT(NOW() + watchDogResetPinDelay);
     watchdogResetGpioPin.Reset();
 
-    constexpr auto baudrate = 10'000'000;
+    constexpr auto baudrate = 6'000'000;
     hal::Initialize(&spi, baudrate);
 
     // Enable Si4463 and wait for PoR to finish

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -620,7 +620,7 @@ auto SetTxType(TxType txType) -> void
     constexpr auto modemModType2Gfsk = 0x03_b;
     constexpr auto nProperties = 6;
     constexpr auto startIndex = 0x00_b;
-    // Inconsistend naming pattern due to strict adherence to datasheet
+    // Inconsistent naming pattern due to strict adherence to datasheet
     constexpr auto modemMapControl = 0x00_b;
     constexpr auto modemDsmCtrl = 0x07_b;
 

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -15,14 +15,10 @@
 
 #include <rodos_no_using_namespace.h>
 
-#include <algorithm>
 #include <array>
 #include <bit>
-#include <climits>
 #include <cstddef>
-#include <iterator>
 #include <span>
-#include <type_traits>
 
 
 namespace sts1cobcsw::rf

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -641,15 +641,15 @@ auto SetTxType(TxType txType) -> void
     auto modemModType = (txType == TxType::morse ? modemModTypeMorse : modemModType2Gfsk);
     auto dataRate = (txType == TxType::morse ? dataRateMorse : dataRate2Gfsk);
 
-    auto propertyValues = std::to_array(
-        {modemModType,
-         0x00_b,
-         0x07_b,  // NOLINT(*magic-numbers*), Delta-Sigma Modulator (DSM) default config
-         static_cast<Byte>(dataRate >> (2 * CHAR_BIT)),  // NOLINT(hicpp-signed-bitwise)
-         static_cast<Byte>(dataRate >> (CHAR_BIT)),      // NOLINT(hicpp-signed-bitwise)
-         static_cast<Byte>(dataRate)});
-
-    SetProperties(PropertyGroup::modem, 0x00_b, Span(propertyValues));
+    SetProperties(
+        PropertyGroup::modem,
+        0x00_b,
+        Span({modemModType,
+              0x00_b,
+              0x07_b,  // NOLINT(*magic-numbers*), Delta-Sigma Modulator (DSM) default config
+              static_cast<Byte>(dataRate >> (2 * CHAR_BIT)),  // NOLINT(hicpp-signed-bitwise)
+              static_cast<Byte>(dataRate >> (CHAR_BIT)),      // NOLINT(hicpp-signed-bitwise)
+              static_cast<Byte>(dataRate)}));
 }
 
 

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -688,16 +688,14 @@ auto PowerUp(PowerUpBootOptions bootOptions,
              PowerUpXtalOptions xtalOptions,
              std::uint32_t xoFrequency) -> void
 {
-    auto const powerUpBuffer = std::to_array<Byte>(
-        {cmdPowerUp,
-         static_cast<Byte>(bootOptions),
-         static_cast<Byte>(xtalOptions),
-         static_cast<Byte>(xoFrequency >> (CHAR_BIT * 3)),  // NOLINT(hicpp-signed-bitwise)
-         static_cast<Byte>(xoFrequency >> (CHAR_BIT * 2)),  // NOLINT(hicpp-signed-bitwise)
-         static_cast<Byte>(xoFrequency >> (CHAR_BIT)),      // NOLINT(hicpp-signed-bitwise)
-         static_cast<Byte>(xoFrequency)});
-
-    SendCommand(Span(powerUpBuffer));
+    SendCommand(
+        Span({cmdPowerUp,
+              static_cast<Byte>(bootOptions),
+              static_cast<Byte>(xtalOptions),
+              static_cast<Byte>(xoFrequency >> (CHAR_BIT * 3)),  // NOLINT(hicpp-signed-bitwise)
+              static_cast<Byte>(xoFrequency >> (CHAR_BIT * 2)),  // NOLINT(hicpp-signed-bitwise)
+              static_cast<Byte>(xoFrequency >> (CHAR_BIT)),      // NOLINT(hicpp-signed-bitwise)
+              static_cast<Byte>(xoFrequency)}));
 }
 
 

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -94,7 +94,7 @@ constexpr auto watchDogResetPinDelay = 1 * MILLISECONDS;
 
 // --- Private function declarations ---
 
-auto InitializeGpioAndSpi() -> void;
+auto InitializeGpiosAndSpi() -> void;
 auto PowerUp() -> void;
 auto Configure(TxType txType) -> void;
 
@@ -116,10 +116,10 @@ auto Initialize(TxType txType) -> void
     // TODO: Don't forget that WDT_Clear has to be triggered regularely for the TX to work! (even
     // without the watchdog timer on the PCB it needs to be triggered at least once after boot to
     // enable the TX)
-    InitializeGpioAndSpi();
+    InitializeGpiosAndSpi();
     PowerUp();
     Configure(txType);
-    // TODO: Why is this one not set with all the other GPIO pins in InitializeGpioAndSpi()?
+    // TODO: Why is this one not set with all the other GPIO pins in InitializeGpiosAndSpi()?
     paEnablePin.Direction(hal::PinDirection::out);
     paEnablePin.Set();
 }
@@ -163,7 +163,7 @@ auto SetTxType(TxType txType) -> void
 
 // --- Private function definitions ---
 
-auto InitializeGpioAndSpi() -> void
+auto InitializeGpiosAndSpi() -> void
 {
     csGpioPin.Direction(hal::PinDirection::out);
     csGpioPin.Set();

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -292,9 +292,10 @@ auto Initialize(TxType txType) -> void
 
     // RF Modem Mod Type
     SetTxType(txType);
+    // SetTxType sets modem properties from 0x00 to 0x05
     SetProperties(
         PropertyGroup::modem,
-        0x06_b,  // SetTxType sets modem properties from 0x00 to 0x05
+        0x06_b,
         Span({0x00_b,  // MODEM_TX_NCO_MODE: TXOSR=x10=0, NCOMOD=F_XTAL/10=2600000=0x027ac40
               0x27_b,
               0xAC_b,

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -92,19 +92,18 @@ auto paEnablePin = hal::GpioPin(hal::rfPaEnablePin);
 // TODO: This should probably be somewhere else as it is not directly related to the RF module
 auto watchdogResetGpioPin = hal::GpioPin(hal::watchdogClearPin);
 
-// Pause values for pin setting/resetting and PoR
+// Pause values for watchdog reset pin and PoR
 // Jakob: Pause times are VERY generously overestimated
 // TODO: Patrick: Are those delays really necessary? I have never seen something like that for SPI
 // communication
-// TODO: Use delay instead of pause, because that's how we did it everywhere else
 // TODO: Do not use trailing comments since they cause line breaks
-constexpr auto porRunningDelay =
-    20 * MILLISECONDS;  // Pause time to wait for Power on Reset to finish
-constexpr auto porCircuitSettleDelay =
-    100 * MILLISECONDS;  // Time until PoR circuit settles after applying power
-constexpr auto watchDogResetPinDelay =
-    1 * MILLISECONDS;  // Pause time for the sequence reset -> pause -> set -> pause -> reset in
-                       // initialization
+
+// Pause time to wait for Power on Reset to finish
+constexpr auto porRunningDelay = 20 * MILLISECONDS;
+// Time until PoR circuit settles after applying power
+constexpr auto porCircuitSettleDelay = 100 * MILLISECONDS;
+// Pause time for the sequence reset -> pause -> set -> pause -> reset in initialization
+constexpr auto watchDogResetPinDelay = 1 * MILLISECONDS;
 
 
 // --- Private function declarations ---
@@ -147,7 +146,7 @@ auto Initialize(TxType txType) -> void
     // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
     // Global XO Tune 2
     SetProperties(PropertyGroup::global,
-                  /*startProperty=*/0x00_b,
+                  0x00_b,
                   Span({
                       0x52_b,  // GLOBAL_XO_TUNE
                       0x00_b   // GLOBAL_CLK_CFG
@@ -163,14 +162,14 @@ auto Initialize(TxType txType) -> void
 
     // RF Int Ctl Enable
     SetProperties(PropertyGroup::intCtl,
-                  /*startProperty=*/0x00_b,
+                  0x00_b,
                   Span({
                       0x01_b  // INT_CTL: Enable packet handler interrupts
                   }));
 
     // TX Preamble Length
     SetProperties(PropertyGroup::preamble,
-                  /*startProperty=*/0x00_b,
+                  0x00_b,
                   Span({
                       0x00_b,  // PREAMBLE_TX_LENGTH: 0 bytes preamble
                       0x14_b,  // PREAMBLE_CONFIG_STD_1: Normal sync timeout,
@@ -190,7 +189,7 @@ auto Initialize(TxType txType) -> void
 
     // Sync word config
     SetProperties(PropertyGroup::sync,
-                  /*startProperty=*/0x00_b,
+                  0x00_b,
                   Span({
                       0x43_b,        // SYNC_CONFIG: Allow 4 bit sync word errors, 4 byte sync word
                       0b01011000_b,  // SYNC_BITS: Valid CCSDS TM sync word for
@@ -205,14 +204,14 @@ auto Initialize(TxType txType) -> void
 
     // CRC Config
     SetProperties(PropertyGroup::pkt,
-                  /*startProperty=*/0x00_b,
+                  0x00_b,
                   Span({
                       0x00_b  // PKT_CRC_CONFIG: No CRC
                   }));
 
     // Whitening and Packet Parameters
     SetProperties(PropertyGroup::pkt,
-                  /*startProperty=*/0x05_b,
+                  0x05_b,
                   Span({
                       0x00_b,  // PKT_WHT_BIT_NUM: Disable whitening
                       0x01_b   // PKT_CONFIG1: Don't split RX and TX field information (length,
@@ -222,7 +221,7 @@ auto Initialize(TxType txType) -> void
 
     // Pkt Length part 1
     SetProperties(PropertyGroup::pkt,
-                  /*startProperty=*/0x08_b,
+                  0x08_b,
                   Span({
                       0x60_b,  // PKT_LEN: Infinite receive, big endian (MSB first)
                       0x00_b,  // PKT_LEN_FIELD_SOURCE
@@ -242,7 +241,7 @@ auto Initialize(TxType txType) -> void
 
     // Pkt Length part 2
     SetProperties(PropertyGroup::pkt,
-                  /*startProperty=*/0x14_b,
+                  0x14_b,
                   Span({
                       0x00_b,  // PKT_FIELD_2_CRC_CONFIG
                       0x00_b,  // PKT_FIELD_3_LENGTH
@@ -260,7 +259,7 @@ auto Initialize(TxType txType) -> void
 
     // Pkt Length part 3
     SetProperties(PropertyGroup::pkt,
-                  /*startProperty=*/0x20_b,
+                  0x20_b,
                   Span({
                       0x00_b,  // PKT_FIELD_5_CRC_CONFIG
                       0x00_b,  // PKT_RX_FIELD_1_LENGTH
@@ -278,7 +277,7 @@ auto Initialize(TxType txType) -> void
 
     // Pkt Length part 4
     SetProperties(PropertyGroup::pkt,
-                  /*startProperty=*/0x2C_b,
+                  0x2C_b,
                   Span({
                       0x00_b,  // PKT_RX_FIELD_3_CRC_CONFIG
                       0x00_b,  // PKT_RX_FIELD_4_LENGTH
@@ -295,7 +294,7 @@ auto Initialize(TxType txType) -> void
     SetTxType(txType);
     SetProperties(
         PropertyGroup::modem,
-        /*startProperty=*/0x06_b,  // SetTxType sets modem properties from 0x00 to 0x05
+        0x06_b,  // SetTxType sets modem properties from 0x00 to 0x05
         Span({0x00_b,  // MODEM_TX_NCO_MODE: TXOSR=x10=0, NCOMOD=F_XTAL/10=2600000=0x027ac40
               0x27_b,
               0xAC_b,
@@ -310,7 +309,7 @@ auto Initialize(TxType txType) -> void
     // Cfg
     SetProperties(
         PropertyGroup::modem,
-        /*startProperty=*/0x18_b,
+        0x18_b,
         Span({
             0x01_b,  // MODEM_TX_RAMP_DELAY: Ramp Delay 1
             0x80_b,  // MODEM_MDM_CTRL: Slicer phase source from detector's output
@@ -334,7 +333,7 @@ auto Initialize(TxType txType) -> void
     // TODO: What values to use here?
     SetProperties(
         PropertyGroup::modem,
-        /*startProperty=*/0x22_b,
+        0x22_b,
         Span({
             0x03_b,  // MODEM_BCR_OSR: RX symbol oversampling rate of 0x30D/8 = 781/8
                      // = 97.625 (According to the datasheet usual values are in the range
@@ -359,7 +358,7 @@ auto Initialize(TxType txType) -> void
     // TODO: What values to use here?
     SetProperties(
         PropertyGroup::modem,
-        /*startProperty=*/0x2C_b,
+        0x2C_b,
         Span({
             0x04_b,  // MODEM_AFC_GEAR: AFC_SLOW gain 4, AFC_FAST gain 0, Switch gear
                      // after detection of preamble
@@ -381,7 +380,7 @@ auto Initialize(TxType txType) -> void
     // TODO: What values to use here?
     SetProperties(
         PropertyGroup::modem,
-        /*startProperty=*/0x35_b,
+        0x35_b,
         Span({
             0xE2_b  // MODEM_AGC_CONTROL: reset peak detectors only on change of gain
                     // indicated by peak detector output, reduce ADC gain when AGC gain is at
@@ -394,7 +393,7 @@ auto Initialize(TxType txType) -> void
     // Gain, 4FSK Slicer Threshold, 4FSK SYmbol Mapping Code, OOK Attack/Decay Times
     // TODO: What values to use here?
     SetProperties(PropertyGroup::modem,
-                  /*startProperty=*/0x38_b,
+                  0x38_b,
                   Span({
                       0x11_b,  // MODEM_AGC_WINDOW_SIZE: AGC gain settling window size = 1, AGC
                                // signal level measurement window = 1
@@ -413,7 +412,7 @@ auto Initialize(TxType txType) -> void
     // Antenna Diversity Control, RSSI Threshold
     SetProperties(
         PropertyGroup::modem,
-        /*startProperty=*/0x42_b,
+        0x42_b,
         Span({
             0xA4_b,  // MODEM_OOK_CNT1: OOK Squelch off, OOK slicer output de-glitching by bit
                      // clock, raw output is synced to clock, MA_FREQUDOWN=0, AGC and OOK movign
@@ -434,7 +433,7 @@ auto Initialize(TxType txType) -> void
 
     // RF Modem RSSI Control
     SetProperties(PropertyGroup::modem,
-                  /*startProperty=*/0x4C_b,
+                  0x4C_b,
                   Span({
                       0x00_b  // MODEM_RSSI_CONTROL: Disable RSSI latch, RSSI value is avg over
                               // last 4*Tb bit periods, disable RSSI threshold check after latch
@@ -443,14 +442,14 @@ auto Initialize(TxType txType) -> void
     // RF Modem RSSI Compensation
     // TODO: Measure this
     SetProperties(PropertyGroup::modem,
-                  /*startProperty=*/0x4E_b,
+                  0x4E_b,
                   Span({
                       0x40_b  // MODEM_RSSI_COMP: Compensation/offset of measured RSSI value
                   }));
 
     // RF Modem Clock generation Band
     SetProperties(PropertyGroup::modem,
-                  /*startProperty=*/0x51_b,
+                  0x51_b,
                   Span({
                       0x0A_b  // MODEM_CLKGEN_BAND: Band = FVCO_DIV_8, high performance mode fixed
                               // prescaler div2, force recalibration
@@ -459,7 +458,7 @@ auto Initialize(TxType txType) -> void
     // RX Filter Coefficients
     // TODO: What values to use here?
     SetProperties(PropertyGroup::modemChflt,
-                  /*startProperty=*/0x00_b,
+                  0x00_b,
                   Span({
                       0xFF_b,  // RX1_CHFLT_COE13[7:0]
                       0xC4_b,  // RX1_CHFLT_COE12[7:0]
@@ -477,7 +476,7 @@ auto Initialize(TxType txType) -> void
 
     SetProperties(
         PropertyGroup::modemChflt,
-        /*startProperty=*/0x0C_b,
+        0x0C_b,
         Span({
             0x03_b,  // RX1_CHFLT_COE1[7:0]
             0x00_b,  // RX1_CHFLT_COE0[7:0]
@@ -498,7 +497,7 @@ auto Initialize(TxType txType) -> void
 
     SetProperties(
         PropertyGroup::modemChflt,
-        /*startProperty=*/0x18_b,
+        0x18_b,
         Span({
             0xB8_b,  // RX2_CHFLT_COE7[7:0]
             0xDE_b,  // RX2_CHFLT_COE6[7:0]
@@ -519,7 +518,7 @@ auto Initialize(TxType txType) -> void
 
     // RF PA Mode
     SetProperties(PropertyGroup::pa,
-                  /*startProperty=*/0x00_b,
+                  0x00_b,
                   Span({
                       0x08_b,  // PA_MODE: PA switching amp mode, PA_SEL = HP_COARSE, disable power
                                // sequencing, disable external TX ramp signal
@@ -535,7 +534,7 @@ auto Initialize(TxType txType) -> void
     // Scaling Factor, FF Loop Filter Values
     // TODO: What values to use here?
     SetProperties(PropertyGroup::synth,
-                  /*startProperty=*/0x00_b,
+                  0x00_b,
                   Span({
                       0x2C_b,  // SYNTH_PFDCP_CPFF: FF charge pump current = 60µA
                       0x0E_b,  // SYNTH_PFDCP_CPINT: Int charge pump current = 30µA
@@ -549,7 +548,7 @@ auto Initialize(TxType txType) -> void
 
     // RF Match Mask
     SetProperties(PropertyGroup::match,
-                  /*startProperty=*/0x00_b,
+                  0x00_b,
                   Span({
                       0x00_b,  // MATCH_VALUE_1
                       0x00_b,  // MATCH_MASK_1
@@ -568,7 +567,7 @@ auto Initialize(TxType txType) -> void
     // Frequency Control
     SetProperties(
         PropertyGroup::freqControl,
-        /*startProperty=*/0x00_b,
+        0x00_b,
         Span({
             0x41_b,  // FREQ_CONTROL_INTE: FC_inte = 0x41
             0x0E_b,  // FREQ_CONTROL_FRAC: FC_frac. 0xD89D9 = 433.5, 0xEC4EC = 434.5
@@ -597,7 +596,7 @@ auto Initialize(TxType txType) -> void
 
     // Frequency Adjust (stolen from Arduino demo code)
     SetProperties(PropertyGroup::global,
-                  /*startProperty=*/0x00_b,
+                  0x00_b,
                   Span({
                       0x62_b  // GLOBAL_XO_TUNE
                   }));
@@ -605,7 +604,7 @@ auto Initialize(TxType txType) -> void
     // Change sequencer mode to guaranteed
     // TODO: Why?
     SetProperties(PropertyGroup::global,
-                  /*startProperty=*/0x03_b,
+                  0x03_b,
                   Span({
                       0x40_b  // GLOBAL_CONFIG: Split FIFO and guaranteed sequencer mode
                   }));

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -26,20 +26,6 @@ using RODOS::MILLISECONDS;
 using RODOS::NOW;
 
 
-enum class PowerUpBootOptions : std::uint8_t
-{
-    noPatch = 0x01,
-    patch = 0x81
-};
-
-
-enum class PowerUpXtalOptions : std::uint8_t
-{
-    xtal = 0x00,  // Reference signal is derived from the internal crystal oscillator
-    txco = 0x01   // Reference signal is derived from an external TCXO
-};
-
-
 enum class PropertyGroup : std::uint8_t
 {
     global = 0x00,       //
@@ -60,8 +46,6 @@ enum class PropertyGroup : std::uint8_t
 
 
 // --- Private globals ---
-
-constexpr std::uint32_t powerUpXoFrequency = 26'000'000;  // 26 MHz
 
 // Si4463 commands
 constexpr auto cmdPartInfo = 0x01_b;
@@ -110,9 +94,7 @@ constexpr auto watchDogResetPinDelay = 1 * MILLISECONDS;
 
 auto InitializeGpioAndSpi() -> void;
 
-auto PowerUp(PowerUpBootOptions bootOptions,
-             PowerUpXtalOptions xtalOptions,
-             std::uint32_t xoFrequency) -> void;
+auto PowerUp() -> void;
 
 auto SendCommand(std::span<Byte const> data) -> void;
 
@@ -138,7 +120,7 @@ auto Initialize(TxType txType) -> void
 
     InitializeGpioAndSpi();
 
-    PowerUp(PowerUpBootOptions::noPatch, PowerUpXtalOptions::xtal, powerUpXoFrequency);
+    PowerUp();
 
     // GPIO Pin Cfg
     SendCommand(Span({cmdGpioPinCfg, 0x00_b, 0x00_b, 0x00_b, 0x00_b, 0x00_b, 0x00_b, 0x00_b}));
@@ -641,6 +623,7 @@ auto SetTxType(TxType txType) -> void
     auto modemModType = (txType == TxType::morse ? modemModTypeMorse : modemModType2Gfsk);
     auto dataRate = (txType == TxType::morse ? dataRateMorse : dataRate2Gfsk);
 
+    // TODO: Use serialize/deserialize
     SetProperties(
         PropertyGroup::modem,
         0x00_b,
@@ -659,15 +642,11 @@ auto InitializeGpioAndSpi() -> void
 {
     csGpioPin.Direction(hal::PinDirection::out);
     csGpioPin.Set();
-
     nirqGpioPin.Direction(hal::PinDirection::in);
-
     sdnGpioPin.Direction(hal::PinDirection::out);
     sdnGpioPin.Set();
-
     gpio0GpioPin.Direction(hal::PinDirection::out);
     gpio0GpioPin.Reset();
-
     watchdogResetGpioPin.Direction(hal::PinDirection::out);
     watchdogResetGpioPin.Reset();
     AT(NOW() + watchDogResetPinDelay);
@@ -685,18 +664,21 @@ auto InitializeGpioAndSpi() -> void
 }
 
 
-auto PowerUp(PowerUpBootOptions bootOptions,
-             PowerUpXtalOptions xtalOptions,
-             std::uint32_t xoFrequency) -> void
+auto PowerUp() -> void
 {
+    constexpr auto bootOption = 0x01_b;
+    constexpr auto xtalOption = 0x00_b;
+    constexpr std::uint32_t powerUpXoFrequency = 26'000'000;  // 26 MHz
+
+    // TODO: Use serialize/deserialize
     SendCommand(
         Span({cmdPowerUp,
-              static_cast<Byte>(bootOptions),
-              static_cast<Byte>(xtalOptions),
-              static_cast<Byte>(xoFrequency >> (CHAR_BIT * 3)),  // NOLINT(hicpp-signed-bitwise)
-              static_cast<Byte>(xoFrequency >> (CHAR_BIT * 2)),  // NOLINT(hicpp-signed-bitwise)
-              static_cast<Byte>(xoFrequency >> (CHAR_BIT)),      // NOLINT(hicpp-signed-bitwise)
-              static_cast<Byte>(xoFrequency)}));
+              bootOption,
+              xtalOption,
+              static_cast<Byte>(powerUpXoFrequency >> (CHAR_BIT * 3)),  // NOLINT(hicpp-signed-bitwise)
+              static_cast<Byte>(powerUpXoFrequency >> (CHAR_BIT * 2)),  // NOLINT(hicpp-signed-bitwise)
+              static_cast<Byte>(powerUpXoFrequency >> (CHAR_BIT)),      // NOLINT(hicpp-signed-bitwise)
+              static_cast<Byte>(powerUpXoFrequency)}));
 }
 
 

--- a/Sts1CobcSw/Periphery/Rf.hpp
+++ b/Sts1CobcSw/Periphery/Rf.hpp
@@ -15,4 +15,5 @@ enum class TxType
 
 auto Initialize(TxType txType) -> void;
 auto ReadPartNumber() -> std::uint16_t;
+auto SetTxType(TxType txType) -> void;
 }

--- a/Sts1CobcSw/Utility/FlatArray.hpp
+++ b/Sts1CobcSw/Utility/FlatArray.hpp
@@ -1,0 +1,55 @@
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <type_traits>
+
+
+namespace sts1cobcsw
+{
+template<typename T>
+inline constexpr std::size_t flatArraySize = 1;
+
+template<typename T, std::size_t size>
+inline constexpr std::size_t flatArraySize<std::array<T, size>> = size;
+
+template<typename T, std::size_t size>
+inline constexpr std::size_t flatArraySize<const std::array<T, size>> = size;
+
+
+//! @brief  Create a flat `std::array` from the given arrays and/or values.
+//!
+//! All arguments must be of the same type `T` or `std::array<T, size>`, although the sizes of the
+//! arrays can differ. The order of the elements in the resulting array is the same as the order of
+//! the arguments.
+//!
+//! The return type `std::array<T, size>` is not explicitly specified because computing `T` and
+//! `size` from the arguments is not trivial.
+template<typename... Args>
+constexpr auto FlatArray(Args const &... args)
+{
+    // NOLINTNEXTLINE(readability-identifier-naming)
+    auto Data = []<typename T>(T const & arrayOrValue)
+    {
+        constexpr bool hasData = requires(T t) { std::data(t); };
+        if constexpr(hasData)
+        {
+            return std::data(arrayOrValue);
+        }
+        else
+        {
+            return &arrayOrValue;
+        }
+    };
+    using T = std::remove_cvref_t<decltype(*(Data(args), ...))>;
+    static_assert((std::same_as<T, std::remove_cvref_t<decltype(*(Data(args)))>> && ...),
+                  "All arguments of FlatArray() must all be of type T or array-of-T");
+
+    auto result = std::array<T, (0U + ... + flatArraySize<Args>)>{};
+    if constexpr(result.size() != 0)
+    {
+        auto iterator = result.begin();
+        ((iterator = std::copy_n(Data(args), flatArraySize<Args>, iterator)), ...);
+    }
+    return result;
+}
+}

--- a/Sts1CobcSw/Utility/FlatArray.hpp
+++ b/Sts1CobcSw/Utility/FlatArray.hpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <span>
 #include <type_traits>
 
 
@@ -15,12 +16,29 @@ inline constexpr std::size_t flatArraySize<std::array<T, size>> = size;
 template<typename T, std::size_t size>
 inline constexpr std::size_t flatArraySize<const std::array<T, size>> = size;
 
+template<typename T, std::size_t extent>
+    requires(extent != std::dynamic_extent)
+inline constexpr std::size_t flatArraySize<std::span<T, extent>> = extent;
 
-//! @brief  Create a flat `std::array` from the given arrays and/or values.
+template<typename T, std::size_t extent>
+    requires(extent != std::dynamic_extent)
+inline constexpr std::size_t flatArraySize<std::span<T const, extent>> = extent;
+
+// Not sure if we need the following two overloads as well, but better safe than sorry
+template<typename T, std::size_t extent>
+    requires(extent != std::dynamic_extent)
+inline constexpr std::size_t flatArraySize<const std::span<T, extent>> = extent;
+
+template<typename T, std::size_t extent>
+    requires(extent != std::dynamic_extent)
+inline constexpr std::size_t flatArraySize<const std::span<T const, extent>> = extent;
+
+
+//! @brief  Create a flat `std::array` from the given arrays, spans, and values.
 //!
-//! All arguments must be of the same type `T` or `std::array<T, size>`, although the sizes of the
-//! arrays can differ. The order of the elements in the resulting array is the same as the order of
-//! the arguments.
+//! All arguments must be of the same type `T`, `std::array<T, size>`, or `std::span<T, extent>`.
+//! The sizes/extents of the arrays/spans can differ, but the spans must not have dynamic extent.
+//! The order of the elements in the resulting array is the same as the order of the arguments.
 //!
 //! The return type `std::array<T, size>` is not explicitly specified because computing `T` and
 //! `size` from the arguments is not trivial.

--- a/Sts1CobcSw/Utility/FlatArray.hpp
+++ b/Sts1CobcSw/Utility/FlatArray.hpp
@@ -48,6 +48,7 @@ constexpr auto FlatArray(Args const &... args)
     // NOLINTNEXTLINE(readability-identifier-naming)
     auto Data = []<typename T>(T const & arrayOrValue)
     {
+        // TODO: Use .data() instead of std::data()
         constexpr bool hasData = requires(T t) { std::data(t); };
         if constexpr(hasData)
         {
@@ -59,8 +60,10 @@ constexpr auto FlatArray(Args const &... args)
         }
     };
     using T = std::remove_cvref_t<decltype(*(Data(args), ...))>;
+    // TODO: Turn this into a constraint if possible because than we can test it in the same way as
+    // Span()
     static_assert((std::same_as<T, std::remove_cvref_t<decltype(*(Data(args)))>> && ...),
-                  "All arguments of FlatArray() must all be of type T or array-of-T");
+                  "All arguments of FlatArray() must all be of type T, array-of-T, or span-of-T");
 
     auto result = std::array<T, (0U + ... + flatArraySize<Args>)>{};
     if constexpr(result.size() != 0)

--- a/Tests/GoldenTests/CMakeLists.txt
+++ b/Tests/GoldenTests/CMakeLists.txt
@@ -9,7 +9,7 @@ add_golden_test(
     TESTFILE "HelloWorld.test.cpp" SOURCE "${Sts1CobcSw}/TopicsAndSubscribers.cpp" LIB rodos::rodos
 )
 
-add_golden_test(TESTFILE "HelloDummy.test.cpp" LIB rodos::rodos Sts1CobcSw_Dummy)
+add_golden_test(TESTFILE "HelloDummy.test.cpp" LIB rodos::rodos etl::etl Sts1CobcSw_Dummy)
 
 add_golden_test(TESTFILE "UpdateRingBuffer.test.cpp" LIB rodos::rodos Sts1CobcSw_Edu)
 

--- a/Tests/GoldenTests/DispatchCommand.test.cpp
+++ b/Tests/GoldenTests/DispatchCommand.test.cpp
@@ -1,11 +1,13 @@
 #include <Sts1CobcSw/CommandParser.hpp>
-#include <Sts1CobcSw/Edu/Edu.hpp>
+#include <Sts1CobcSw/Edu/ProgramQueue.hpp>
 #include <Sts1CobcSw/Serial/Byte.hpp>
+#include <Sts1CobcSw/Serial/Serial.hpp>
 
 #include <rodos_no_using_namespace.h>
 
 #include <etl/vector.h>
 
+#include <algorithm>
 #include <cstdint>
 
 

--- a/Tests/GoldenTests/HelloDummy.test.cpp
+++ b/Tests/GoldenTests/HelloDummy.test.cpp
@@ -2,6 +2,8 @@
 
 #include <rodos_no_using_namespace.h>
 
+#include <etl/string.h>
+
 #include <cstdint>
 
 

--- a/Tests/GoldenTests/UpdateRingBuffer.test.cpp
+++ b/Tests/GoldenTests/UpdateRingBuffer.test.cpp
@@ -1,4 +1,3 @@
-#include <Sts1CobcSw/Dummy.hpp>
 #include <Sts1CobcSw/Edu/ProgramStatusHistory.hpp>
 
 // clang-format off

--- a/Tests/HardwareTests/Crc32.test.cpp
+++ b/Tests/HardwareTests/Crc32.test.cpp
@@ -31,8 +31,10 @@
 #include <rodos_no_using_namespace.h>
 
 #include <array>
-#include <cinttypes>
+#include <cstddef>
+#include <cstdint>
 #include <span>
+#include <type_traits>
 
 
 namespace sts1cobcsw

--- a/Tests/HardwareTests/EduCommands.test.cpp
+++ b/Tests/HardwareTests/EduCommands.test.cpp
@@ -3,14 +3,14 @@
 #include <Sts1CobcSw/Hal/IoNames.hpp>
 #include <Sts1CobcSw/Hal/Uart.hpp>
 #include <Sts1CobcSw/Serial/Byte.hpp>
-#include <Sts1CobcSw/Serial/Serial.hpp>
-#include <Sts1CobcSw/Utility/Span.hpp>
 #include <Sts1CobcSw/Utility/Time.hpp>
 
 #include <rodos_no_using_namespace.h>
 
+#include <array>
 #include <charconv>
 #include <cinttypes>
+#include <cstddef>
 #include <cstdint>
 #include <span>
 
@@ -84,17 +84,17 @@ private:
                     PRINTF("Please enter a program ID (1 character)\n");
                     auto userInput = ReadCharacters<1>();
                     std::uint16_t programId = 0;
-                    std::from_chars(begin(userInput), end(userInput), programId);
+                    std::from_chars(userInput.begin(), userInput.end(), programId);
 
                     PRINTF("Please enter a start time (1 character)\n");
                     userInput = ReadCharacters<1>();
                     std::int32_t startTime = 0;
-                    std::from_chars(begin(userInput), end(userInput), startTime);
+                    std::from_chars(userInput.begin(), userInput.end(), startTime);
 
                     PRINTF("Please enter a timeout (1 character)\n");
                     userInput = ReadCharacters<1>();
                     std::int16_t timeout = 0;
-                    std::from_chars(begin(userInput), end(userInput), timeout);
+                    std::from_chars(userInput.begin(), userInput.end(), timeout);
 
                     PRINTF("\n");
                     PRINTF("Sending ExecuteProgram(programId = %" PRIu16 ", startTime = %" PRIi32
@@ -138,12 +138,12 @@ private:
                     PRINTF("Please enter a program ID (1 character)\n");
                     auto userInput = ReadCharacters<1>();
                     std::uint16_t programId = 0;
-                    std::from_chars(begin(userInput), end(userInput), programId);
+                    std::from_chars(userInput.begin(), userInput.end(), programId);
 
                     PRINTF("Please enter a start time (1 character)\n");
                     userInput = ReadCharacters<1>();
                     std::int32_t startTime = 0;
-                    std::from_chars(begin(userInput), end(userInput), startTime);
+                    std::from_chars(userInput.begin(), userInput.end(), startTime);
 
                     PRINTF("\n");
                     PRINTF("Sending ReturnResult(programId = %" PRIu16 ", startTime = %" PRIi32

--- a/Tests/HardwareTests/FileSystem.test.cpp
+++ b/Tests/HardwareTests/FileSystem.test.cpp
@@ -4,7 +4,6 @@
 
 #include <rodos_no_using_namespace.h>
 
-#include <array>
 #include <cstddef>
 
 

--- a/Tests/HardwareTests/Flash.test.cpp
+++ b/Tests/HardwareTests/Flash.test.cpp
@@ -7,8 +7,8 @@
 
 #include <algorithm>
 #include <cinttypes>
+#include <cstddef>
 #include <cstdint>
-#include <string_view>
 
 
 namespace sts1cobcsw
@@ -74,7 +74,7 @@ private:
         Print(page);
 
         PRINTF("\n");
-        std::fill(begin(page), end(page), 0x00_b);
+        std::fill(page.begin(), page.end(), 0x00_b);
         PRINTF("Programming page at address 0x%08x:\n", static_cast<unsigned int>(pageAddress));
         Print(page);
         auto begin = RODOS::NOW();

--- a/Tests/HardwareTests/Fram.test.cpp
+++ b/Tests/HardwareTests/Fram.test.cpp
@@ -8,8 +8,11 @@
 #include <rodos_no_using_namespace.h>
 
 #include <algorithm>
+#include <array>
 #include <cinttypes>
+#include <cstddef>
 #include <cstdint>
+#include <span>
 
 
 namespace sts1cobcsw
@@ -18,7 +21,7 @@ using RODOS::PRINTF;
 using sts1cobcsw::operator""_b;  // NOLINT(misc-unused-using-decls)
 
 
-const size_t testDataSize = 11 * 1024;  // 11 KiB
+const std::size_t testDataSize = 11 * 1024;  // 11 KiB
 auto testData = std::array<Byte, testDataSize>{};
 auto readData = std::array<Byte, testDataSize>{};
 

--- a/Tests/HardwareTests/Gpio.test.cpp
+++ b/Tests/HardwareTests/Gpio.test.cpp
@@ -1,6 +1,5 @@
 #include <Sts1CobcSw/Hal/GpioPin.hpp>
 #include <Sts1CobcSw/Hal/IoNames.hpp>
-#include <Sts1CobcSw/Hal/PinNames.hpp>
 
 #include <rodos_no_using_namespace.h>
 

--- a/Tests/HardwareTests/ThreadTests/EduPowerManagement.test.cpp
+++ b/Tests/HardwareTests/ThreadTests/EduPowerManagement.test.cpp
@@ -2,12 +2,8 @@
 #include <Sts1CobcSw/Hal/GpioPin.hpp>
 #include <Sts1CobcSw/Hal/IoNames.hpp>
 #include <Sts1CobcSw/Hal/Uart.hpp>
-#include <Sts1CobcSw/TopicsAndSubscribers.hpp>
 
 #include <rodos_no_using_namespace.h>
-
-#include <charconv>
-#include <cstdint>
 
 
 namespace sts1cobcsw

--- a/Tests/HardwareTests/Uart.test.cpp
+++ b/Tests/HardwareTests/Uart.test.cpp
@@ -6,9 +6,7 @@
 //!
 //! After flashing the COBC just follow the instructions on the screen.
 
-#include <Sts1CobcSw/Hal/GpioPin.hpp>
 #include <Sts1CobcSw/Hal/IoNames.hpp>
-#include <Sts1CobcSw/Hal/PinNames.hpp>
 #include <Sts1CobcSw/Hal/Uart.hpp>
 #include <Sts1CobcSw/Serial/Byte.hpp>
 #include <Sts1CobcSw/Utility/Span.hpp>
@@ -19,7 +17,6 @@
 #include <charconv>
 #include <cinttypes>
 #include <cstddef>
-#include <span>
 
 
 namespace sts1cobcsw
@@ -32,7 +29,7 @@ template<std::size_t nDigits = 1>
 auto ToChars(int i)
 {
     auto string = std::array<char, nDigits>{};
-    std::to_chars(data(string), data(string) + size(string), i);
+    std::to_chars(string.data(), string.data() + string.size(), i);
     return string;
 }
 

--- a/Tests/HardwareTests/Utility.cpp
+++ b/Tests/HardwareTests/Utility.cpp
@@ -9,11 +9,11 @@ auto Check(bool condition, std::string_view failMessage, std::string_view succes
 {
     if(condition)
     {
-        RODOS::PRINTF("%s", data(successMessage));
+        RODOS::PRINTF("%s", successMessage.data());
     }
     else
     {
-        RODOS::PRINTF("%s", data(failMessage));
+        RODOS::PRINTF("%s", failMessage.data());
     }
 }
 }

--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -2,6 +2,9 @@
 add_program(Dummy Dummy.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Dummy PRIVATE Catch2::Catch2WithMain Sts1CobcSw_Dummy)
 
+add_program(FlatArray FlatArray.test.cpp)
+target_link_libraries(Sts1CobcSwTests_FlatArray PRIVATE Catch2::Catch2WithMain Sts1CobcSw_Utility)
+
 add_program(Outcome Outcome.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Outcome PRIVATE Catch2::Catch2WithMain)
 

--- a/Tests/UnitTests/Dummy.test.cpp
+++ b/Tests/UnitTests/Dummy.test.cpp
@@ -2,6 +2,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <etl/string.h>
+
 
 TEST_CASE("Always passes")
 {

--- a/Tests/UnitTests/FlatArray.test.cpp
+++ b/Tests/UnitTests/FlatArray.test.cpp
@@ -1,0 +1,116 @@
+#include <Sts1CobcSw/Utility/FlatArray.hpp>
+
+// #include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <array>
+#include <span>
+#include <type_traits>
+
+
+using sts1cobcsw::FlatArray;
+
+
+struct S
+{
+    int i = 1;
+};
+
+
+auto operator==(S const & lhs, S const & rhs) -> bool
+{
+    return lhs.i == rhs.i;
+}
+
+
+// We cannot test if FlatArray() of different types does not compile because the CallFlatArray trick
+// does not work here. The reason is that we use a static_assert() in FlatArray() instead of a
+// requires clause.
+TEST_CASE("FlatArray() from values of the same type")
+{
+    REQUIRE(FlatArray(1) == std::array{1});
+    REQUIRE(FlatArray(1U, 2U) == std::array{1U, 2U});
+    REQUIRE(FlatArray(1L, 2L, 3L) == std::array{1L, 2L, 3L});
+    REQUIRE(FlatArray(1.1, 2.2, 3.3, 4.4) == std::array{1.1, 2.2, 3.3, 4.4});
+    REQUIRE(FlatArray(S(), S(), S()) == std::array{S(), S(), S()});
+}
+
+
+// Mix const and non-const arrays
+static constexpr auto a1 = std::array{1};
+auto const a2 = std::array{2, 3};
+auto a3 = std::array{4, 5, 6};
+
+
+TEST_CASE("FlatArray() from arrays of the same type")
+{
+    // Single arrays with different lengths
+    REQUIRE(FlatArray(a1) == a1);
+    REQUIRE(FlatArray(a2) == a2);
+    REQUIRE(FlatArray(a3) == a3);
+
+    // Multiple arrays with same length
+    REQUIRE(FlatArray(a1, a1) == std::array{1, 1});
+    REQUIRE(FlatArray(a2, a2) == std::array{2, 3, 2, 3});
+    REQUIRE(FlatArray(a3, a3) == std::array{4, 5, 6, 4, 5, 6});
+    REQUIRE(FlatArray(a3, a3, a3) == std::array{4, 5, 6, 4, 5, 6, 4, 5, 6});
+
+    // Multiple arrays with different lengths
+    REQUIRE(FlatArray(a1, a2) == std::array{1, 2, 3});
+    REQUIRE(FlatArray(a2, a3) == std::array{2, 3, 4, 5, 6});
+    REQUIRE(FlatArray(a3, a1) == std::array{4, 5, 6, 1});
+    REQUIRE(FlatArray(a1, a2, a3) == std::array{1, 2, 3, 4, 5, 6});
+    REQUIRE(FlatArray(a2, a3, a1) == std::array{2, 3, 4, 5, 6, 1});
+    REQUIRE(FlatArray(a3, a1, a2) == std::array{4, 5, 6, 1, 2, 3});
+}
+
+
+// Mix all constnesses of spans
+auto s1 = std::span<int const, 1>{a1};
+auto const s2 = std::span<int const, 2>{a2};
+auto s3 = std::span<int, 3>{a3};
+auto const s4 = std::span<int, 3>{a3};
+
+
+TEST_CASE("FlatArray() from spans of the same type")
+{
+    // Single spans with different lengths
+    REQUIRE(FlatArray(s1) == a1);
+    REQUIRE(FlatArray(s2) == a2);
+    REQUIRE(FlatArray(s3) == a3);
+    REQUIRE(FlatArray(s4) == a3);
+
+    // Multiple spans with same length
+    REQUIRE(FlatArray(s1, s1) == std::array{1, 1});
+    REQUIRE(FlatArray(s2, s2) == std::array{2, 3, 2, 3});
+    REQUIRE(FlatArray(s3, s3) == std::array{4, 5, 6, 4, 5, 6});
+    REQUIRE(FlatArray(s4, s4) == std::array{4, 5, 6, 4, 5, 6});
+    REQUIRE(FlatArray(s3, s3, s3) == std::array{4, 5, 6, 4, 5, 6, 4, 5, 6});
+}
+
+
+TEST_CASE("FlatArray() from values, arrays, and spans of the same type")
+{
+    // Mix values and arrays
+    REQUIRE(FlatArray(0, a1) == std::array{0, 1});
+    REQUIRE(FlatArray(a2, 0) == std::array{2, 3, 0});
+    REQUIRE(FlatArray(0, 0, a3) == std::array{0, 0, 4, 5, 6});
+    REQUIRE(FlatArray(0, a2, 0) == std::array{0, 2, 3, 0});
+    REQUIRE(FlatArray(a1, 0, a3) == std::array{1, 0, 4, 5, 6});
+
+    // Mix values and spans
+    REQUIRE(FlatArray(0, s1) == std::array{0, 1});
+    REQUIRE(FlatArray(s2, 0) == std::array{2, 3, 0});
+    REQUIRE(FlatArray(0, 0, s3) == std::array{0, 0, 4, 5, 6});
+    REQUIRE(FlatArray(0, s2, 0) == std::array{0, 2, 3, 0});
+    REQUIRE(FlatArray(s1, 0, s4) == std::array{1, 0, 4, 5, 6});
+
+    // Mix values, arrays, and spans
+    REQUIRE(FlatArray(0, a1, s1) == std::array{0, 1, 1});
+    REQUIRE(FlatArray(a2, 0, s2) == std::array{2, 3, 0, 2, 3});
+    REQUIRE(FlatArray(s3, a3, 0) == std::array{4, 5, 6, 4, 5, 6, 0});
+    REQUIRE(FlatArray(s4, 0, a1) == std::array{4, 5, 6, 0, 1});
+    REQUIRE(FlatArray(1, a1, s1, a2, s2, a3, s3)
+            == std::array{1, 1, 1, 2, 3, 2, 3, 4, 5, 6, 4, 5, 6});
+}

--- a/Tests/UnitTests/Outcome.test.cpp
+++ b/Tests/UnitTests/Outcome.test.cpp
@@ -5,9 +5,10 @@
 
 #include <algorithm>
 #include <cctype>
-#include <iostream>
+#include <cstdlib>
 #include <limits>
 #include <string>
+#include <utility>
 
 
 // First define a policy

--- a/Tests/UnitTests/Serial.test.cpp
+++ b/Tests/UnitTests/Serial.test.cpp
@@ -7,6 +7,7 @@
 #include <bit>
 #include <cstddef>
 #include <cstdint>
+#include <span>
 #include <type_traits>
 
 using sts1cobcsw::Byte;

--- a/Tests/UnitTests/Span.test.cpp
+++ b/Tests/UnitTests/Span.test.cpp
@@ -3,6 +3,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <array>
+#include <span>
 #include <type_traits>
 #include <utility>
 

--- a/iwyu.imp
+++ b/iwyu.imp
@@ -60,11 +60,11 @@
   { include: ["\"Sts1CobcSw/Serial/Byte.hpp\"",           "public", "<Sts1CobcSw/Serial/Byte.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Serial/Serial.hpp\"",         "public", "<Sts1CobcwSw/Serial/Serial.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Utility/Span.hpp\"",          "public", "<Sts1CobcSw/Utility/Span.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Utility/FlatArray.hpp\"",     "public", "<Sts1CobcSw/Utility/FlatArray.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Edu/Structs.hpp\"",           "public", "<Sts1CobcSw/Edu/Structs.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Hal/Uart.hpp\"",              "public", "<Sts1CobcSw/Hal/Uart.hpp>", "public"] },
 
   # Fixing iwyu bug where <tuple> is required to be include for array symbol
   # unfortunately, the `symbol` directive does not work
   { include: ["<tuple>", "public", "<array>", "public"] },
-
 ]

--- a/iwyu.imp
+++ b/iwyu.imp
@@ -1,4 +1,4 @@
-[ 
+[
   # Include only rodos_no_using_namespace
   { include: ["<rodos-version.h>",              "private", "<rodos_no_using_namespace.h>", "public"] },
   { include: ["<default-platform-parameter.h>", "private", "<rodos_no_using_namespace.h>", "public"] },
@@ -41,28 +41,50 @@
   # Include support libs we use by their full path
   { include: ["<ringbuffer.h>", "private", "<rodos/support/support-libs/ringbuffer.h>", "public"] },
 
+  # Mappings for the ETL
+  { include: ["<etl/basic_string.h>", "private", "<etl/string.h>", "public"] },
+
+  # Instead of all our .ipp files include the .hpp ones
+  { include: ["\"Sts1CobcSw/Edu/Structs.ipp\"",           "private", "<Sts1CobcSw/Edu/Structs.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/FileSystem/FileSystem.ipp\"", "private", "<Sts1CobcSw/FileSystem/FileSystem.hpp>", "public"] },
-  { include: ["\"Sts1CobcSw/Hal/Spi.ipp\"",               "private", "<Sts1CobcSw/Hal/Spi.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Hal/GpioPin.ipp\"",           "private", "<Sts1CobcSw/Hal/GpioPin.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Hal/Spi.ipp\"",               "private", "<Sts1CobcSw/Hal/Spi.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Hal/Uart.ipp\"",              "private", "<Sts1CobcSw/Hal/Uart.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Utility/Time.ipp\"",          "private", "<Sts1CobcSw/Utility/Time.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Periphery/Fram.ipp\"",        "private", "<Sts1CobcSw/Periphery/Fram.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Serial/Byte.ipp\"",           "private", "<Sts1CobcSw/Serial/Byte.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Serial/Serial.ipp\"",         "private", "<Sts1CobcSw/Serial/Serial.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Utility/Span.ipp\"",          "private", "<Sts1CobcSw/Utility/Span.hpp>", "public"] },
-  { include: ["\"Sts1CobcSw/Edu/Structs.ipp\"",           "private", "<Sts1CobcSw/Edu/Structs.hpp>", "public"] },
-  { include: ["\"Sts1CobcSw/Hal/Uart.ipp\"",              "private", "<Sts1CobcSw/Hal/Uart.hpp>", "public"] },
 
-  { include: ["\"Sts1CobcSw/FileSystem/FileSystem.hpp\"", "public", "<Sts1CobcSw/FileSystem/FileSystem.hpp>", "public"] },
-  { include: ["\"Sts1CobcSw/Hal/Spi.hpp\"",               "public", "<Sts1CobcSw/Hal/Spi.hpp>", "public"] },
-  { include: ["\"Sts1CobcSw/Hal/GpioPin.hpp\"",           "public", "<Sts1CobcSw/Hal/GpioPin.hpp>", "public"] },
-  { include: ["\"Sts1CobcSw/Utility/Time.hpp\"",          "public", "<Sts1CobcSw/Utility/Time.hpp>", "public"] },
-  { include: ["\"Sts1CobcSw/Periphery/Fram.hpp\"",        "public", "<Sts1CobcSw/Periphery/Fram.hpp>", "public"] },
-  { include: ["\"Sts1CobcSw/Serial/Byte.hpp\"",           "public", "<Sts1CobcSw/Serial/Byte.hpp>", "public"] },
-  { include: ["\"Sts1CobcSw/Serial/Serial.hpp\"",         "public", "<Sts1CobcwSw/Serial/Serial.hpp>", "public"] },
-  { include: ["\"Sts1CobcSw/Utility/Span.hpp\"",          "public", "<Sts1CobcSw/Utility/Span.hpp>", "public"] },
-  { include: ["\"Sts1CobcSw/Utility/FlatArray.hpp\"",     "public", "<Sts1CobcSw/Utility/FlatArray.hpp>", "public"] },
-  { include: ["\"Sts1CobcSw/Edu/Structs.hpp\"",           "public", "<Sts1CobcSw/Edu/Structs.hpp>", "public"] },
-  { include: ["\"Sts1CobcSw/Hal/Uart.hpp\"",              "public", "<Sts1CobcSw/Hal/Uart.hpp>", "public"] },
+  # Include all our headers with <> instead of ""
+  { include: ["\"Sts1CobcSw/Edu/Edu.hpp\"",                     "public", "<Sts1CobcSw/Edu/Edu.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Edu/ProgramQueue.hpp\"",            "public", "<Sts1CobcSw/Edu/ProgramQueue.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Edu/ProgramStatusHistory.hpp\"",    "public", "<Sts1CobcSw/Edu/ProgramStatusHistory.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Edu/Types.hpp\"",                   "public", "<Sts1CobcSw/Edu/Types.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/FileSystem/FileSystem.hpp\"",       "public", "<Sts1CobcSw/FileSystem/FileSystem.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Hal/GpioPin.hpp\"",                 "public", "<Sts1CobcSw/Hal/GpioPin.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Hal/IoNames.hpp\"",                 "public", "<Sts1CobcSw/Hal/IoNames.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Hal/PinNames.hpp\"",                "public", "<Sts1CobcSw/Hal/PinNames.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Hal/Spi.hpp\"",                     "public", "<Sts1CobcSw/Hal/Spi.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Hal/Uart.hpp\"",                    "public", "<Sts1CobcSw/Hal/Uart.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Outcome/Outcome.hpp\"",             "public", "<Sts1CobcSw/Outcome/Outcome.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Periphery/Eps.hpp\"",               "public", "<Sts1CobcSw/Periphery/Eps.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Periphery/Flash.hpp\"",             "public", "<Sts1CobcSw/Periphery/Flash.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Periphery/Fram.hpp\"",              "public", "<Sts1CobcSw/Periphery/Fram.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Periphery/PersistentState.hpp\"",   "public", "<Sts1CobcSw/Periphery/PersistentState.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Periphery/Rf.hpp\"",                "public", "<Sts1CobcSw/Periphery/Rf.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Serial/Byte.hpp\"",                 "public", "<Sts1CobcSw/Serial/Byte.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Serial/Serial.hpp\"",               "public", "<Sts1CobcwSw/Serial/Serial.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Utility/Crc32.hpp\"",               "public", "<Sts1CobcSw/Utility/Crc32.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Utility/FlatArray.hpp\"",           "public", "<Sts1CobcSw/Utility/FlatArray.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Utility/Span.hpp\"",                "public", "<Sts1CobcSw/Utility/Span.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Utility/Time.hpp\"",                "public", "<Sts1CobcSw/Utility/Time.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/CommandParser.hpp\"",               "public", "<Sts1CobcSw/CommandParser.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/EduCommunicationErrorThread.hpp\"", "public", "<Sts1CobcSw/EduCommunicationErrorThread.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/EduListenerThread.hpp\"",           "public", "<Sts1CobcSw/EduListenerThread.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/EduProgramQueueThread.hpp\"",       "public", "<Sts1CobcSw/EduProgramQueueThread.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/ThreadPriorites.hpp\"",             "public", "<Sts1CobcSw/ThreadPriorites.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/TopicsAndSubscribers.hpp\"",        "public", "<Sts1CobcSw/TopicsAndSubscribers.hpp>", "public"] },
 
   # Fixing iwyu bug where <tuple> is required to be include for array symbol
   # unfortunately, the `symbol` directive does not work


### PR DESCRIPTION
### Description

This PR

- contains a refactoring of the code used to initialize and configure the RF module. Old functions based on passing a pointer and length have been replaced with our span-based `SetProperties()` and `SendCommand()`. Furthermore, the obvious magic values have been moved into constants, and the delays in the SPI communication have been removed.
- introduces `FlatArray()`, a function to create a flat `std::array` from values, arrays, spans, or a mix thereof.
- adds all our .hpp and .ipp files to iwyu.imp and orders them alphabetically.
- fixes all `#includes` according to IWYU.

Fixes #224