### PR TITLE
Add read function for EPS sensors

### DIFF
--- a/Sts1CobcSw/EduListenerThread.cpp
+++ b/Sts1CobcSw/EduListenerThread.cpp
@@ -7,7 +7,6 @@
 #include <Sts1CobcSw/Hal/IoNames.hpp>
 #include <Sts1CobcSw/ThreadPriorities.hpp>
 #include <Sts1CobcSw/TopicsAndSubscribers.hpp>
-#include <Sts1CobcSw/Utility/Debug.hpp>
 
 #include <rodos_no_using_namespace.h>
 

--- a/Sts1CobcSw/Periphery/Eps.cpp
+++ b/Sts1CobcSw/Periphery/Eps.cpp
@@ -111,7 +111,7 @@ auto Initialize() -> void
     adc6CsGpioPin.Direction(hal::PinDirection::out);
     adc6CsGpioPin.Set();
 
-    constexpr auto baudrate = 6'000'000;
+    static constexpr auto baudrate = 6'000'000;
     Initialize(&framEpsSpi, baudrate);
 
     // Setup ADCs
@@ -164,14 +164,15 @@ auto ConfigureSetupRegister(hal::GpioPin * adcCsPin) -> void
     // [3:2]: Reference mode configuration
     // [1:0]: Don't care
 
-    constexpr auto setupRegister = 0b01_b;
+    static constexpr auto setupRegister = 0b01_b;
     // Don't use CNVST modes, we use the analog configuration for the CNVST pin
     // Therefore clock mode = 0b10 << 4: No CNVST, internal clock
-    constexpr auto clockMode = 0b10_b;
+    static constexpr auto clockMode = 0b10_b;
     // Reference off after scan; need wake-up delay: 0b00
     // Reference always on; no wake-up delay: 0b10
-    constexpr auto referenceMode = 0b00_b;
-    constexpr auto setupData = (setupRegister << 6) | (clockMode << 4) | (referenceMode << 2);
+    static constexpr auto referenceMode = 0b00_b;
+    static constexpr auto setupData =
+        (setupRegister << 6) | (clockMode << 4) | (referenceMode << 2);
 
     // Changing to CNVST mode could be bad (analog input in digital pin)
     // So statically check that bit 5 is set to 1
@@ -192,14 +193,14 @@ auto ConfigureAveragingRegister(hal::GpioPin * adcCsPin) -> void
     // [1:0]: Single-channel scan count (scan mode 0b10 in conversion only)
 
     // TODO: discuss and chose averaging values
-    constexpr auto averagingRegister = 0b001_b;
+    static constexpr auto averagingRegister = 0b001_b;
     // Averaging off for now
-    constexpr auto enableAveraging = 0b0_b;
+    static constexpr auto enableAveraging = 0b0_b;
     // Only relevant with averaging on, average 4 conversions
-    constexpr auto nAverages = 0b00_b;
+    static constexpr auto nAverages = 0b00_b;
     // Probably not relevant, leave on 4 results
-    constexpr auto nSingleScans = 0b00_b;
-    constexpr auto averagingData =
+    static constexpr auto nSingleScans = 0b00_b;
+    static constexpr auto averagingData =
         (averagingRegister << 5) | (enableAveraging << 4) | (nAverages << 2) | nSingleScans;
 
     adcCsPin->Reset();
@@ -218,14 +219,15 @@ auto ReadAdc(hal::GpioPin * adcCsPin, std::span<Byte, adcDataLength> adcData) ->
     // [2:1]: Scan mode
     // [1]: Don't care
 
-    constexpr auto readDelay = 3 * RODOS::MILLISECONDS;
-    constexpr auto conversionRegister = 0b1_b;
+    static constexpr auto readDelay = 3 * RODOS::MILLISECONDS;
+    static constexpr auto conversionRegister = 0b1_b;
     // Select highest channel, since we scan through all of them every time
-    constexpr auto channel = 0b1111_b;
+    static constexpr auto channel = 0b1111_b;
     // Scan through channel 0 to N (set in channel select)
     // -> All channels in our case
-    constexpr auto scanMode = 0b00_b;
-    constexpr auto conversionData = (conversionRegister << 7) | (channel << 3) | (scanMode << 1);
+    static constexpr auto scanMode = 0b00_b;
+    static constexpr auto conversionData =
+        (conversionRegister << 7) | (channel << 3) | (scanMode << 1);
 
     adcCsPin->Reset();
     hal::WriteTo(&spi, Span(conversionData));

--- a/Sts1CobcSw/Periphery/Eps.cpp
+++ b/Sts1CobcSw/Periphery/Eps.cpp
@@ -4,6 +4,7 @@
 #include <Sts1CobcSw/Periphery/Eps.hpp>
 #include <Sts1CobcSw/Periphery/FramEpsSpi.hpp>
 #include <Sts1CobcSw/Serial/Byte.hpp>
+#include <Sts1CobcSw/Serial/Serial.hpp>
 #include <Sts1CobcSw/Utility/Span.hpp>
 
 #include <rodos_no_using_namespace.h>
@@ -95,6 +96,9 @@ auto adc6CsGpioPin = hal::GpioPin(hal::epsAdc6CsPin);
 auto ConfigureSetupRegister(hal::GpioPin * adcCsPin) -> void;
 auto Reset(hal::GpioPin * adcCsPin, ResetType resetType) -> void;
 
+auto ConfigureAveragingRegister(hal::GpioPin * adcCsPin) -> void;
+
+auto ReadAdc(hal::GpioPin * adcCsPin, std::span<Byte, adcDataLength> adcData) -> void;
 
 // --- Public function definitions ---
 
@@ -114,6 +118,23 @@ auto Initialize() -> void
     ConfigureSetupRegister(&adc4CsGpioPin);
     ConfigureSetupRegister(&adc5CsGpioPin);
     ConfigureSetupRegister(&adc6CsGpioPin);
+
+    // Set averaging mode
+    ConfigureAveragingRegister(&adc4CsGpioPin);
+    ConfigureAveragingRegister(&adc5CsGpioPin);
+    ConfigureAveragingRegister(&adc6CsGpioPin);
+}
+
+
+auto Read() -> std::array<Byte, adcDataLength * nAdcs>
+{
+    auto sensorData = std::array<Byte, adcDataLength * nAdcs>{};
+
+    ReadAdc(&adc4CsGpioPin, Span(&sensorData).subspan<0, adcDataLength>());
+    ReadAdc(&adc5CsGpioPin, Span(&sensorData).subspan<adcDataLength, adcDataLength>());
+    ReadAdc(&adc6CsGpioPin, Span(&sensorData).subspan<2 * adcDataLength, adcDataLength>());
+
+    return sensorData;
 }
 
 
@@ -140,15 +161,15 @@ auto ConfigureSetupRegister(hal::GpioPin * adcCsPin) -> void
     // Setup register values
     // [7:6]: Register selection bits = 0b01
     // [5:4]: Clock mode and CNVST configuration
-    //      Don't use CNVST modes, we use the analog configuration for the CNVST pin
-    //      Therefore clock mode = 0b10 << 4: No CNVST, internal clock
     // [3:2]: Reference mode configuration
-    //      Reference off after scan; need wake-up delay: 0b00
-    //      Reference always on; no wake-up delay: 0b10
     // [1:0]: Don't care
 
     constexpr auto setupRegister = 0b01_b;
+    // Don't use CNVST modes, we use the analog configuration for the CNVST pin
+    // Therefore clock mode = 0b10 << 4: No CNVST, internal clock
     constexpr auto clockMode = 0b10_b;
+    // Reference off after scan; need wake-up delay: 0b00
+    // Reference always on; no wake-up delay: 0b10
     constexpr auto referenceMode = 0b00_b;
     constexpr auto setupData = (setupRegister << 6) | (clockMode << 4) | (referenceMode << 2);
 
@@ -158,6 +179,68 @@ auto ConfigureSetupRegister(hal::GpioPin * adcCsPin) -> void
 
     adcCsPin->Reset();
     hal::WriteTo(&framEpsSpi, Span(setupData), spiTimeout);
+    adcCsPin->Set();
+}
+
+
+auto ConfigureAveragingRegister(hal::GpioPin * adcCsPin) -> void
+{
+    // Averaging register values
+    // [7:5]: Register selection bits = 0b001
+    // [4]: Averaging on/off
+    // [3:2]: Number of conversions used
+    // [1:0]: Single-channel scan count (scan mode 0b10 in conversion only)
+
+    constexpr auto averagingRegister = 0b001_b;
+    // Averaging off for now
+    constexpr auto enableAveraging = 0b0_b;
+    // Only relevant with averaging on, average 4 conversions
+    constexpr auto nAverages = 0b00_b;
+    // Probably not relevant, leave on 4 results
+    constexpr auto nSingleScans = 0b00_b;
+    constexpr auto averagingData =
+        (averagingRegister << 5) | (enableAveraging << 4) | (nAverages << 2) | nSingleScans;
+
+    adcCsPin->Reset();
+    hal::WriteTo(&spi, Span(averagingData));
+    adcCsPin->Set();
+}
+
+
+auto ReadAdc(hal::GpioPin * adcCsPin, std::span<Byte, adcDataLength> adcData) -> void
+{
+    // Send conversion byte
+
+    // Conversion register values
+    // [7]: Register selection bit = 0b1
+    // [6:3]: Channel select
+    // [2:1]: Scan mode
+    // [1]: Don't care
+
+    constexpr auto readDelay = 3 * RODOS::MILLISECONDS;
+    constexpr auto conversionRegister = 0b1_b;
+    // Select highest channel, since we scan through all of them every time
+    constexpr auto channel = 0b1111_b;
+    // Scan through channel 0 to N (set in channel select)
+    // -> All channels in our case
+    constexpr auto scanMode = 0b00_b;
+    constexpr auto conversionData = (conversionRegister << 7) | (channel << 3) | (scanMode << 1);
+
+    adcCsPin->Reset();
+    hal::WriteTo(&spi, Span(conversionData));
+    adcCsPin->Set();
+
+    // Leave enough time for max. 514 conversions
+    // t_acq = 0.6 us
+    // t_conv = 3.5 us
+    // 514 * (t_acq + t_conv) = 2107.4 us
+    // TODO: This delay can be brought down if we fix the number of averages
+    RODOS::AT(RODOS::NOW() + readDelay);
+
+    // Resolution is 12 bit, sent like this:
+    // 0 0 0 0 MSB x x x, x x x x x x x LSB
+    adcCsPin->Reset();
+    hal::ReadFrom(&spi, adcData);
     adcCsPin->Set();
 }
 

--- a/Sts1CobcSw/Periphery/Eps.cpp
+++ b/Sts1CobcSw/Periphery/Eps.cpp
@@ -199,7 +199,7 @@ auto ConfigureAveragingRegister(hal::GpioPin * adcCsPin) -> void
     static constexpr auto averagingData =
         (averagingRegister << 5) | (enableAveraging << 4) | (nAverages << 2) | nSingleScans;
     adcCsPin->Reset();
-    hal::WriteTo(&spi, Span(averagingData));
+    hal::WriteTo(&framEpsSpi, Span(averagingData), spiTimeout);
     adcCsPin->Set();
 }
 
@@ -219,7 +219,7 @@ auto ReadAdc(hal::GpioPin * adcCsPin) -> AdcValues
     static constexpr auto conversionCommand =
         (conversionRegister << 7) | (channel << 3) | (scanMode << 1);
     adcCsPin->Reset();
-    hal::WriteTo(&spi, Span(conversionCommand));
+    hal::WriteTo(&framEpsSpi, Span(conversionCommand), spiTimeout);
     adcCsPin->Set();
 
     // According to the datasheet at most 514 conversions are done after a conversion command
@@ -231,7 +231,7 @@ auto ReadAdc(hal::GpioPin * adcCsPin) -> AdcValues
     // Resolution is 12 bit, sent like this: [0 0 0 0 MSB x x x], [x x x x x x x LSB]
     auto adcData = Buffer<AdcValues>{};
     adcCsPin->Reset();
-    hal::ReadFrom(&spi, Span(&adcData));
+    hal::ReadFrom(&framEpsSpi, Span(&adcData), spiTimeout);
     adcCsPin->Set();
     return Deserialize<std::endian::big, AdcValues>(Span(adcData));
 }

--- a/Sts1CobcSw/Periphery/Eps.cpp
+++ b/Sts1CobcSw/Periphery/Eps.cpp
@@ -195,7 +195,7 @@ auto ConfigureAveragingRegister(hal::GpioPin * adcCsPin) -> void
     // TODO: discuss and chose averaging values
     static constexpr auto averagingRegister = 0b001_b;
     // Averaging off for now
-    static constexpr auto enableAveraging = 0b0_b;
+    static constexpr auto enableAveraging = 0b1_b;
     // Only relevant with averaging on, average 4 conversions
     static constexpr auto nAverages = 0b00_b;
     // Probably not relevant, leave on 4 results

--- a/Sts1CobcSw/Periphery/Eps.cpp
+++ b/Sts1CobcSw/Periphery/Eps.cpp
@@ -191,6 +191,7 @@ auto ConfigureAveragingRegister(hal::GpioPin * adcCsPin) -> void
     // [3:2]: Number of conversions used
     // [1:0]: Single-channel scan count (scan mode 0b10 in conversion only)
 
+    // TODO: discuss and chose averaging values
     constexpr auto averagingRegister = 0b001_b;
     // Averaging off for now
     constexpr auto enableAveraging = 0b0_b;

--- a/Sts1CobcSw/Periphery/Eps.cpp
+++ b/Sts1CobcSw/Periphery/Eps.cpp
@@ -233,7 +233,7 @@ auto ReadAdc(hal::GpioPin * adcCsPin, std::span<Byte, adcDataLength> adcData) ->
     // Leave enough time for max. 514 conversions
     // t_acq = 0.6 us
     // t_conv = 3.5 us
-    // 514 * (t_acq + t_conv) = 2107.4 us
+    // 514 * (t_acq + t_conv) + wakeup = 2172.4 us
     // TODO: This delay can be brought down if we fix the number of averages
     RODOS::AT(RODOS::NOW() + readDelay);
 

--- a/Sts1CobcSw/Periphery/Eps.cpp
+++ b/Sts1CobcSw/Periphery/Eps.cpp
@@ -235,12 +235,12 @@ auto ReadAdc(hal::GpioPin * adcCsPin) -> AdcValues
     static constexpr auto readDelay = 3 * RODOS::MILLISECONDS;
     RODOS::AT(RODOS::NOW() + readDelay);
 
-    // Resolution is 12 bit, sent like this: 0 0 0 0 MSB x x x, x x x x x x x LSB
+    // Resolution is 12 bit, sent like this: [0 0 0 0 MSB x x x], [x x x x x x x LSB]
     auto adcData = Buffer<AdcValues>{};
     adcCsPin->Reset();
     hal::ReadFrom(&spi, Span(&adcData));
     adcCsPin->Set();
-    return Deserialize<AdcValues>(Span(adcData));
+    return Deserialize<std::endian::big, AdcValues>(Span(adcData));
 }
 
 

--- a/Sts1CobcSw/Periphery/Eps.hpp
+++ b/Sts1CobcSw/Periphery/Eps.hpp
@@ -1,19 +1,18 @@
 #pragma once
 
-#include <Sts1CobcSw/Serial/Byte.hpp>
-
 #include <array>
+#include <cstdint>
 
 
 namespace sts1cobcsw::eps
 {
-constexpr auto nChannels = 16U;
-constexpr auto adcDataLength = 2 * nChannels;
-constexpr auto nAdcs = 3U;
-constexpr auto sensorDataLength = nAdcs * adcDataLength;
+inline constexpr auto nAdcs = 3U;
+inline constexpr auto nChannels = 16U;
+using AdcValue = std::uint16_t;
+using SensorValues = std::array<AdcValue, nChannels * nAdcs>;
 
 auto Initialize() -> void;
-auto Read() -> std::array<Byte, sensorDataLength>;
+auto Read() -> SensorValues;
 auto ResetAdcRegisters() -> void;
 auto ClearFifos() -> void;
 }

--- a/Sts1CobcSw/Periphery/Eps.hpp
+++ b/Sts1CobcSw/Periphery/Eps.hpp
@@ -1,9 +1,19 @@
 #pragma once
 
+#include <Sts1CobcSw/Serial/Byte.hpp>
+
+#include <array>
+
 
 namespace sts1cobcsw::eps
 {
+constexpr auto nChannels = 16U;
+constexpr auto adcDataLength = 2 * nChannels;
+constexpr auto nAdcs = 3U;
+constexpr auto sensorDataLength = nAdcs * adcDataLength;
+
 auto Initialize() -> void;
+auto Read() -> std::array<Byte, sensorDataLength>;
 auto ResetAdcRegisters() -> void;
 auto ClearFifos() -> void;
 }

--- a/Sts1CobcSw/Serial/Serial.hpp
+++ b/Sts1CobcSw/Serial/Serial.hpp
@@ -45,6 +45,9 @@ inline constexpr std::size_t serialSize = 0;
 template<TriviallySerializable T>
 inline constexpr std::size_t serialSize<T> = sizeof(T);
 
+template<typename T, std::size_t size>
+inline constexpr std::size_t serialSize<std::array<T, size>> = serialSize<T> * size;
+
 template<typename... Ts>
 inline constexpr std::size_t totalSerialSize = (serialSize<Ts> + ...);
 
@@ -77,9 +80,16 @@ template<std::endian endianness, std::default_initializable T>
 template<std::endian endianness, TriviallySerializable T>
 [[nodiscard]] auto SerializeTo(void * destination, T const & t) -> void *;
 
+template<std::endian endianness, typename T, std::size_t size>
+[[nodiscard]] auto SerializeTo(void * destination, std::array<T, size> const & array) -> void *;
+
 // Must be overloaded for user-defined types to be deserializable
 template<std::endian endianness, TriviallySerializable T>
 [[nodiscard]] auto DeserializeFrom(void const * source, T * t) -> void const *;
+
+template<std::endian endianness, typename T, std::size_t size>
+[[nodiscard]] auto DeserializeFrom(void const * source, std::array<T, size> * array)
+    -> void const *;
 
 template<HasEndianness T>
 [[nodiscard]] constexpr auto ReverseBytes(T t) -> T;

--- a/Sts1CobcSw/Serial/Serial.hpp
+++ b/Sts1CobcSw/Serial/Serial.hpp
@@ -14,7 +14,6 @@
 
 
 #include <Sts1CobcSw/Serial/Byte.hpp>
-#include <Sts1CobcSw/Serial/Serial.hpp>
 
 // We need std::byteswap which is C++23 but for some reason clang-tidy crashes when using C++23, so
 // we use the ETL version

--- a/Sts1CobcSw/Serial/Serial.ipp
+++ b/Sts1CobcSw/Serial/Serial.ipp
@@ -55,6 +55,17 @@ inline auto SerializeTo(void * destination, T const & t) -> void *
 }
 
 
+template<std::endian endianness, typename T, std::size_t size>
+auto SerializeTo(void * destination, std::array<T, size> const & array) -> void *
+{
+    for(auto const & element : array)
+    {
+        destination = SerializeTo<endianness>(destination, element);
+    }
+    return destination;
+}
+
+
 template<std::endian endianness, TriviallySerializable T>
 inline auto DeserializeFrom(void const * source, T * t) -> void const *
 {
@@ -65,6 +76,17 @@ inline auto DeserializeFrom(void const * source, T * t) -> void const *
     }
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     return static_cast<Byte const *>(source) + serialSize<T>;
+}
+
+
+template<std::endian endianness, typename T, std::size_t size>
+auto DeserializeFrom(void const * source, std::array<T, size> * array) -> void const *
+{
+    for(auto & element : *array)
+    {
+        source = DeserializeFrom<endianness>(source, &element);
+    }
+    return source;
 }
 
 

--- a/Tests/HardwareTests/Eps.test.cpp
+++ b/Tests/HardwareTests/Eps.test.cpp
@@ -30,7 +30,9 @@ private:
         PRINTF("EPS ADCs initialized\n");
         PRINTF("\n");
         constexpr auto nSensorValues = eps::nChannels * eps::nAdcs;
-        
+        constexpr auto referenceVoltage = 4.096;
+        constexpr auto resolution = 4096;
+
         TIME_LOOP(0, 2 * RODOS::SECONDS)
         {
             RODOS::PRINTF("Reading...\n");
@@ -41,7 +43,15 @@ private:
             {
                 std::uint16_t value = 0U;
                 dataPointer = DeserializeFrom<std::endian::big>(dataPointer, &value);
-                RODOS::PRINTF("%u", value);
+                auto measuredVoltage = value * (referenceVoltage / resolution);
+                auto adc = static_cast<int>(i / eps::nChannels);
+                auto channel = static_cast<int>(i % eps::nChannels);
+                RODOS::PRINTF(
+                    "ADC %i Channel %i:\n\tDigital reading = %u\n\tMeasured voltage = %f\n",
+                    adc,
+                    channel,
+                    value,
+                    measuredVoltage);
             }
             RODOS::PRINTF("\n");
         }

--- a/Tests/HardwareTests/Eps.test.cpp
+++ b/Tests/HardwareTests/Eps.test.cpp
@@ -1,4 +1,5 @@
 #include <Sts1CobcSw/Periphery/Eps.hpp>
+#include <Sts1CobcSw/Serial/Serial.hpp>
 
 #include <rodos_no_using_namespace.h>
 
@@ -25,13 +26,25 @@ private:
     void run() override
     {
         PRINTF("\nEPS test\n\n");
-
         eps::Initialize();
         PRINTF("EPS ADCs initialized\n");
-
         PRINTF("\n");
-
-        // Here comes the rest of the EPS test
+        constexpr auto nSensorValues = eps::nChannels * eps::nAdcs;
+        
+        TIME_LOOP(0, 2 * RODOS::SECONDS)
+        {
+            RODOS::PRINTF("Reading...\n");
+            auto sensorData = eps::Read();
+            void const * dataPointer = sensorData.data();
+            RODOS::PRINTF("Result:\n");
+            for(size_t i = 0; i < nSensorValues; i++)
+            {
+                std::uint16_t value = 0U;
+                dataPointer = DeserializeFrom<std::endian::big>(dataPointer, &value);
+                RODOS::PRINTF("%u", value);
+            }
+            RODOS::PRINTF("\n");
+        }
     }
 } epsTest;
 }

--- a/Tests/HardwareTests/Eps.test.cpp
+++ b/Tests/HardwareTests/Eps.test.cpp
@@ -47,7 +47,7 @@ private:
             auto measuredVoltage = value * (referenceVoltage / resolution);
             auto adc = static_cast<int>(i / eps::nChannels) + adcIdOffset;
             auto channel = static_cast<int>(i % eps::nChannels);
-            RODOS::PRINTF("ADC %i Channel %i:\n\tDigital reading = %u\n\tMeasured voltage = %f\n",
+            RODOS::PRINTF("ADC %i Channel %i:\n  Digital reading = %u\n  Measured voltage = %f\n",
                           adc,
                           channel,
                           value,


### PR DESCRIPTION
### Description

This PR adds functionality to read the EPS sensors, including a test. What is left to do is testing this on the HW and discussing and choosing the final configuration for the averaging register.

Fixes #213
