### PR TITLE
Add versions of HW tests that feed the watchdog

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -45,7 +45,7 @@ with section("format"):
 
   # If an argument group contains more than this many sub-groups (parg or kwarg
   # groups) then force it to a vertical layout.
-  max_subgroups_hwrap = 2
+  max_subgroups_hwrap = 3
 
   # If a positional argument group contains more than this many arguments, then
   # force it to a vertical layout.
@@ -238,4 +238,3 @@ with section("misc"):
   # A dictionary containing any per-command configuration overrides. Currently
   # only `command_case` is supported.
   per_command = {}
-

--- a/Sts1CobcSw/ThreadPriorities.hpp
+++ b/Sts1CobcSw/ThreadPriorities.hpp
@@ -9,4 +9,5 @@ inline constexpr auto eduProgramQueueThreadPriority = 300;
 inline constexpr auto eduListenerThreadPriority = 100;
 inline constexpr auto eduHeartbeatThreadPriority = 600;
 inline constexpr auto commandParserThreadPriority = 100;
+inline constexpr auto watchdogClearThreadPriority = 600;
 }

--- a/Sts1CobcSw/ThreadPriorities.hpp
+++ b/Sts1CobcSw/ThreadPriorities.hpp
@@ -9,5 +9,4 @@ inline constexpr auto eduProgramQueueThreadPriority = 300;
 inline constexpr auto eduListenerThreadPriority = 100;
 inline constexpr auto eduHeartbeatThreadPriority = 600;
 inline constexpr auto commandParserThreadPriority = 100;
-inline constexpr auto watchdogClearThreadPriority = 600;
 }

--- a/Tests/HardwareTests/CMakeLists.txt
+++ b/Tests/HardwareTests/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(ThreadTests)
 
-# TODO: Add a funtion to make both the "normal" target and its WithWatchdog variant. As the current
+# TODO: Add a function to make both the "normal" target and its WithWatchdog variant. As the current
 # way is against DRY and convoluted.
 add_library(Sts1CobcSwTests_Utility STATIC Utility.cpp)
 target_link_libraries(Sts1CobcSwTests_Utility PRIVATE rodos::rodos)
@@ -15,8 +15,8 @@ target_link_libraries(
 
 add_program(Crc32WithWatchdog Crc32.test.cpp WatchdogClear.test.cpp)
 target_link_libraries(
-    Sts1CobcSwTests_Crc32WithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Utility Sts1CobcSwTests_Utility
-                                  Sts1CobcSw_Hal
+    Sts1CobcSwTests_Crc32WithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Utility
+                                              Sts1CobcSwTests_Utility Sts1CobcSw_Hal
 )
 
 add_program(EduCommands EduCommands.test.cpp)
@@ -27,15 +27,17 @@ target_link_libraries(
 
 add_program(EduCommandsWithWatchdog EduCommands.test.cpp WatchdogClear.test.cpp)
 target_link_libraries(
-    Sts1CobcSwTests_EduCommandsWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Utility Sts1CobcSw_Serial
-                                        Sts1CobcSw_Hal Sts1CobcSw_Edu
+    Sts1CobcSwTests_EduCommandsWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Utility
+                                                    Sts1CobcSw_Serial Sts1CobcSw_Hal Sts1CobcSw_Edu
 )
 
 add_program(Eps Eps.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Eps PRIVATE rodos::rodos Sts1CobcSw_Periphery)
 
 add_program(EpsWithWatchdog Eps.test.cpp WatchdogClear.test.cpp)
-target_link_libraries(Sts1CobcSwTests_EpsWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Hal)
+target_link_libraries(
+    Sts1CobcSwTests_EpsWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Hal
+)
 
 add_program(FileSystem FileSystem.test.cpp)
 target_link_libraries(
@@ -44,8 +46,8 @@ target_link_libraries(
 
 add_program(FileSystemWithWatchdog FileSystem.test.cpp WatchdogClear.test.cpp)
 target_link_libraries(
-    Sts1CobcSwTests_FileSystemWithWatchdog PRIVATE rodos::rodos littlefs::littlefs Sts1CobcSw_FileSystem
-                                       Sts1CobcSw_Hal
+    Sts1CobcSwTests_FileSystemWithWatchdog PRIVATE rodos::rodos littlefs::littlefs
+                                                   Sts1CobcSw_FileSystem Sts1CobcSw_Hal
 )
 
 add_program(Flash Flash.test.cpp)
@@ -57,7 +59,7 @@ target_link_libraries(
 add_program(FlashWithWatchdog Flash.test.cpp WatchdogClear.test.cpp)
 target_link_libraries(
     Sts1CobcSwTests_FlashWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Serial
-                                  Sts1CobcSwTests_Utility Sts1CobcSw_Hal
+                                              Sts1CobcSwTests_Utility Sts1CobcSw_Hal
 )
 
 add_program(Fram Fram.test.cpp)
@@ -68,8 +70,9 @@ target_link_libraries(
 
 add_program(FramWithWatchdog Fram.test.cpp WatchdogClear.test.cpp)
 target_link_libraries(
-    Sts1CobcSwTests_FramWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Serial
-                                 Sts1CobcSw_Utility Sts1CobcSwTests_Utility Sts1CobcSw_Hal
+    Sts1CobcSwTests_FramWithWatchdog
+    PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Serial Sts1CobcSw_Utility
+            Sts1CobcSwTests_Utility Sts1CobcSw_Hal
 )
 
 add_program(Gpio Gpio.test.cpp)
@@ -85,15 +88,17 @@ target_link_libraries(
 
 add_program(RfWithWatchdog Rf.test.cpp WatchdogClear.test.cpp)
 target_link_libraries(
-    Sts1CobcSwTests_RfWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSwTests_Utility
-                               Sts1CobcSw_Hal
+    Sts1CobcSwTests_RfWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Periphery
+                                           Sts1CobcSwTests_Utility Sts1CobcSw_Hal
 )
 
 add_program(Uart Uart.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Uart PRIVATE rodos::rodos Sts1CobcSw_Hal Sts1CobcSw_Utility)
 
 add_program(UartWithWatchdog Uart.test.cpp WatchdogClear.test.cpp)
-target_link_libraries(Sts1CobcSwTests_UartWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Hal Sts1CobcSw_Utility)
+target_link_libraries(
+    Sts1CobcSwTests_UartWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Hal Sts1CobcSw_Utility
+)
 
 add_program(Watchdog Watchdog.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Watchdog PRIVATE rodos::rodos Sts1CobcSw_Hal)

--- a/Tests/HardwareTests/CMakeLists.txt
+++ b/Tests/HardwareTests/CMakeLists.txt
@@ -1,7 +1,15 @@
 add_subdirectory(ThreadTests)
 
-# TODO: Add a function to make both the "normal" target and its WithWatchdog variant. As the current
-# way is against DRY and convoluted.
+function(add_watchdog_version_of program_name)
+    set(target_name ${PROJECT_NAME}_${program_name})
+    get_property(sources TARGET ${target_name} PROPERTY SOURCES)
+    get_property(libraries TARGET ${target_name} PROPERTY LINK_LIBRARIES)
+    add_program(${program_name}WithWatchdog ${sources} WatchdogClear.test.cpp)
+    list(APPEND libraries rodos::rodos Sts1CobcSw_Hal)
+    list(REMOVE_DUPLICATES libraries)
+    target_link_libraries(${target_name}WithWatchdog PRIVATE ${libraries})
+endfunction()
+
 add_library(Sts1CobcSwTests_Utility STATIC Utility.cpp)
 target_link_libraries(Sts1CobcSwTests_Utility PRIVATE rodos::rodos)
 target_include_directories(
@@ -12,93 +20,52 @@ add_program(Crc32 Crc32.test.cpp)
 target_link_libraries(
     Sts1CobcSwTests_Crc32 PRIVATE rodos::rodos Sts1CobcSw_Utility Sts1CobcSwTests_Utility
 )
-
-add_program(Crc32WithWatchdog Crc32.test.cpp WatchdogClear.test.cpp)
-target_link_libraries(
-    Sts1CobcSwTests_Crc32WithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Utility
-                                              Sts1CobcSwTests_Utility Sts1CobcSw_Hal
-)
+add_watchdog_version_of(Crc32)
 
 add_program(EduCommands EduCommands.test.cpp)
 target_link_libraries(
     Sts1CobcSwTests_EduCommands PRIVATE rodos::rodos Sts1CobcSw_Utility Sts1CobcSw_Serial
                                         Sts1CobcSw_Hal Sts1CobcSw_Edu
 )
-
-add_program(EduCommandsWithWatchdog EduCommands.test.cpp WatchdogClear.test.cpp)
-target_link_libraries(
-    Sts1CobcSwTests_EduCommandsWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Utility
-                                                    Sts1CobcSw_Serial Sts1CobcSw_Hal Sts1CobcSw_Edu
-)
+add_watchdog_version_of(EduCommands)
 
 add_program(Eps Eps.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Eps PRIVATE rodos::rodos Sts1CobcSw_Periphery)
-
-add_program(EpsWithWatchdog Eps.test.cpp WatchdogClear.test.cpp)
-target_link_libraries(
-    Sts1CobcSwTests_EpsWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Hal
-)
+add_watchdog_version_of(Eps)
 
 add_program(FileSystem FileSystem.test.cpp)
 target_link_libraries(
     Sts1CobcSwTests_FileSystem PRIVATE rodos::rodos littlefs::littlefs Sts1CobcSw_FileSystem
 )
-
-add_program(FileSystemWithWatchdog FileSystem.test.cpp WatchdogClear.test.cpp)
-target_link_libraries(
-    Sts1CobcSwTests_FileSystemWithWatchdog PRIVATE rodos::rodos littlefs::littlefs
-                                                   Sts1CobcSw_FileSystem Sts1CobcSw_Hal
-)
+add_watchdog_version_of(FileSystem)
 
 add_program(Flash Flash.test.cpp)
 target_link_libraries(
     Sts1CobcSwTests_Flash PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Serial
                                   Sts1CobcSwTests_Utility
 )
-
-add_program(FlashWithWatchdog Flash.test.cpp WatchdogClear.test.cpp)
-target_link_libraries(
-    Sts1CobcSwTests_FlashWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Serial
-                                              Sts1CobcSwTests_Utility Sts1CobcSw_Hal
-)
+add_watchdog_version_of(Flash)
 
 add_program(Fram Fram.test.cpp)
 target_link_libraries(
     Sts1CobcSwTests_Fram PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Serial
                                  Sts1CobcSw_Utility Sts1CobcSwTests_Utility
 )
-
-add_program(FramWithWatchdog Fram.test.cpp WatchdogClear.test.cpp)
-target_link_libraries(
-    Sts1CobcSwTests_FramWithWatchdog
-    PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Serial Sts1CobcSw_Utility
-            Sts1CobcSwTests_Utility Sts1CobcSw_Hal
-)
+add_watchdog_version_of(Fram)
 
 add_program(Gpio Gpio.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Gpio PRIVATE rodos::rodos Sts1CobcSw_Hal)
-
-add_program(GpioWithWatchdog Gpio.test.cpp WatchdogClear.test.cpp)
-target_link_libraries(Sts1CobcSwTests_GpioWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Hal)
+add_watchdog_version_of(Gpio)
 
 add_program(Rf Rf.test.cpp)
 target_link_libraries(
     Sts1CobcSwTests_Rf PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSwTests_Utility
 )
-
-add_program(RfWithWatchdog Rf.test.cpp WatchdogClear.test.cpp)
-target_link_libraries(
-    Sts1CobcSwTests_RfWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Periphery
-                                           Sts1CobcSwTests_Utility Sts1CobcSw_Hal
-)
+add_watchdog_version_of(Rf)
 
 add_program(Uart Uart.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Uart PRIVATE rodos::rodos Sts1CobcSw_Hal Sts1CobcSw_Utility)
-
-add_program(UartWithWatchdog Uart.test.cpp WatchdogClear.test.cpp)
-target_link_libraries(
-    Sts1CobcSwTests_UartWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Hal Sts1CobcSw_Utility
-)
+add_watchdog_version_of(Uart)
 
 add_program(Watchdog Watchdog.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Watchdog PRIVATE rodos::rodos Sts1CobcSw_Hal)

--- a/Tests/HardwareTests/CMakeLists.txt
+++ b/Tests/HardwareTests/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(
 
 add_program(Crc32WithWatchdog Crc32.test.cpp WatchdogClear.test.cpp)
 target_link_libraries(
-    Sts1CobcSwTests_Crc32 PRIVATE rodos::rodos Sts1CobcSw_Utility Sts1CobcSwTests_Utility
+    Sts1CobcSwTests_Crc32WithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Utility Sts1CobcSwTests_Utility
                                   Sts1CobcSw_Hal
 )
 
@@ -27,7 +27,7 @@ target_link_libraries(
 
 add_program(EduCommandsWithWatchdog EduCommands.test.cpp WatchdogClear.test.cpp)
 target_link_libraries(
-    Sts1CobcSwTests_EduCommands PRIVATE rodos::rodos Sts1CobcSw_Utility Sts1CobcSw_Serial
+    Sts1CobcSwTests_EduCommandsWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Utility Sts1CobcSw_Serial
                                         Sts1CobcSw_Hal Sts1CobcSw_Edu
 )
 
@@ -35,7 +35,7 @@ add_program(Eps Eps.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Eps PRIVATE rodos::rodos Sts1CobcSw_Periphery)
 
 add_program(EpsWithWatchdog Eps.test.cpp WatchdogClear.test.cpp)
-target_link_libraries(Sts1CobcSwTests_Eps PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Hal)
+target_link_libraries(Sts1CobcSwTests_EpsWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Hal)
 
 add_program(FileSystem FileSystem.test.cpp)
 target_link_libraries(
@@ -44,7 +44,7 @@ target_link_libraries(
 
 add_program(FileSystemWithWatchdog FileSystem.test.cpp WatchdogClear.test.cpp)
 target_link_libraries(
-    Sts1CobcSwTests_FileSystem PRIVATE rodos::rodos littlefs::littlefs Sts1CobcSw_FileSystem
+    Sts1CobcSwTests_FileSystemWithWatchdog PRIVATE rodos::rodos littlefs::littlefs Sts1CobcSw_FileSystem
                                        Sts1CobcSw_Hal
 )
 
@@ -56,7 +56,7 @@ target_link_libraries(
 
 add_program(FlashWithWatchdog Flash.test.cpp WatchdogClear.test.cpp)
 target_link_libraries(
-    Sts1CobcSwTests_Flash PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Serial
+    Sts1CobcSwTests_FlashWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Serial
                                   Sts1CobcSwTests_Utility Sts1CobcSw_Hal
 )
 
@@ -68,7 +68,7 @@ target_link_libraries(
 
 add_program(FramWithWatchdog Fram.test.cpp WatchdogClear.test.cpp)
 target_link_libraries(
-    Sts1CobcSwTests_Fram PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Serial
+    Sts1CobcSwTests_FramWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Serial
                                  Sts1CobcSw_Utility Sts1CobcSwTests_Utility Sts1CobcSw_Hal
 )
 
@@ -76,7 +76,7 @@ add_program(Gpio Gpio.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Gpio PRIVATE rodos::rodos Sts1CobcSw_Hal)
 
 add_program(GpioWithWatchdog Gpio.test.cpp WatchdogClear.test.cpp)
-target_link_libraries(Sts1CobcSwTests_Gpio PRIVATE rodos::rodos Sts1CobcSw_Hal)
+target_link_libraries(Sts1CobcSwTests_GpioWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Hal)
 
 add_program(Rf Rf.test.cpp)
 target_link_libraries(
@@ -85,7 +85,7 @@ target_link_libraries(
 
 add_program(RfWithWatchdog Rf.test.cpp WatchdogClear.test.cpp)
 target_link_libraries(
-    Sts1CobcSwTests_Rf PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSwTests_Utility
+    Sts1CobcSwTests_RfWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSwTests_Utility
                                Sts1CobcSw_Hal
 )
 
@@ -93,7 +93,7 @@ add_program(Uart Uart.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Uart PRIVATE rodos::rodos Sts1CobcSw_Hal Sts1CobcSw_Utility)
 
 add_program(UartWithWatchdog Uart.test.cpp WatchdogClear.test.cpp)
-target_link_libraries(Sts1CobcSwTests_Uart PRIVATE rodos::rodos Sts1CobcSw_Hal Sts1CobcSw_Utility)
+target_link_libraries(Sts1CobcSwTests_UartWithWatchdog PRIVATE rodos::rodos Sts1CobcSw_Hal Sts1CobcSw_Utility)
 
 add_program(Watchdog Watchdog.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Watchdog PRIVATE rodos::rodos Sts1CobcSw_Hal)

--- a/Tests/HardwareTests/CMakeLists.txt
+++ b/Tests/HardwareTests/CMakeLists.txt
@@ -107,9 +107,7 @@ add_program(WatchdogClear Watchdog.test.cpp WatchdogClear.test.cpp)
 target_link_libraries(Sts1CobcSwTests_WatchdogClear PRIVATE rodos::rodos Sts1CobcSw_Hal)
 
 get_property(
-    top_level_hw_test_targets
-    DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-    PROPERTY BUILDSYSTEM_TARGETS
+    top_level_hw_test_targets DIRECTORY ${CMAKE_CURRENT_LIST_DIR} PROPERTY BUILDSYSTEM_TARGETS
 )
 
 add_custom_target(AllHardwareTests) # Must be defined after getting all hardware test targets

--- a/Tests/HardwareTests/CMakeLists.txt
+++ b/Tests/HardwareTests/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_subdirectory(ThreadTests)
 
+# TODO: Add a funtion to make both the "normal" target and its WithWatchdog variant. As the current
+# way is against DRY and convoluted.
 add_library(Sts1CobcSwTests_Utility STATIC Utility.cpp)
 target_link_libraries(Sts1CobcSwTests_Utility PRIVATE rodos::rodos)
 target_include_directories(
@@ -11,7 +13,19 @@ target_link_libraries(
     Sts1CobcSwTests_Crc32 PRIVATE rodos::rodos Sts1CobcSw_Utility Sts1CobcSwTests_Utility
 )
 
+add_program(Crc32WithWatchdog Crc32.test.cpp WatchdogClear.test.cpp)
+target_link_libraries(
+    Sts1CobcSwTests_Crc32 PRIVATE rodos::rodos Sts1CobcSw_Utility Sts1CobcSwTests_Utility
+                                  Sts1CobcSw_Hal
+)
+
 add_program(EduCommands EduCommands.test.cpp)
+target_link_libraries(
+    Sts1CobcSwTests_EduCommands PRIVATE rodos::rodos Sts1CobcSw_Utility Sts1CobcSw_Serial
+                                        Sts1CobcSw_Hal Sts1CobcSw_Edu
+)
+
+add_program(EduCommandsWithWatchdog EduCommands.test.cpp WatchdogClear.test.cpp)
 target_link_libraries(
     Sts1CobcSwTests_EduCommands PRIVATE rodos::rodos Sts1CobcSw_Utility Sts1CobcSw_Serial
                                         Sts1CobcSw_Hal Sts1CobcSw_Edu
@@ -20,9 +34,18 @@ target_link_libraries(
 add_program(Eps Eps.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Eps PRIVATE rodos::rodos Sts1CobcSw_Periphery)
 
+add_program(EpsWithWatchdog Eps.test.cpp WatchdogClear.test.cpp)
+target_link_libraries(Sts1CobcSwTests_Eps PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Hal)
+
 add_program(FileSystem FileSystem.test.cpp)
 target_link_libraries(
     Sts1CobcSwTests_FileSystem PRIVATE rodos::rodos littlefs::littlefs Sts1CobcSw_FileSystem
+)
+
+add_program(FileSystemWithWatchdog FileSystem.test.cpp WatchdogClear.test.cpp)
+target_link_libraries(
+    Sts1CobcSwTests_FileSystem PRIVATE rodos::rodos littlefs::littlefs Sts1CobcSw_FileSystem
+                                       Sts1CobcSw_Hal
 )
 
 add_program(Flash Flash.test.cpp)
@@ -31,13 +54,28 @@ target_link_libraries(
                                   Sts1CobcSwTests_Utility
 )
 
+add_program(FlashWithWatchdog Flash.test.cpp WatchdogClear.test.cpp)
+target_link_libraries(
+    Sts1CobcSwTests_Flash PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Serial
+                                  Sts1CobcSwTests_Utility Sts1CobcSw_Hal
+)
+
 add_program(Fram Fram.test.cpp)
 target_link_libraries(
     Sts1CobcSwTests_Fram PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Serial
                                  Sts1CobcSw_Utility Sts1CobcSwTests_Utility
 )
 
+add_program(FramWithWatchdog Fram.test.cpp WatchdogClear.test.cpp)
+target_link_libraries(
+    Sts1CobcSwTests_Fram PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSw_Serial
+                                 Sts1CobcSw_Utility Sts1CobcSwTests_Utility Sts1CobcSw_Hal
+)
+
 add_program(Gpio Gpio.test.cpp)
+target_link_libraries(Sts1CobcSwTests_Gpio PRIVATE rodos::rodos Sts1CobcSw_Hal)
+
+add_program(GpioWithWatchdog Gpio.test.cpp WatchdogClear.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Gpio PRIVATE rodos::rodos Sts1CobcSw_Hal)
 
 add_program(Rf Rf.test.cpp)
@@ -45,7 +83,16 @@ target_link_libraries(
     Sts1CobcSwTests_Rf PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSwTests_Utility
 )
 
+add_program(RfWithWatchdog Rf.test.cpp WatchdogClear.test.cpp)
+target_link_libraries(
+    Sts1CobcSwTests_Rf PRIVATE rodos::rodos Sts1CobcSw_Periphery Sts1CobcSwTests_Utility
+                               Sts1CobcSw_Hal
+)
+
 add_program(Uart Uart.test.cpp)
+target_link_libraries(Sts1CobcSwTests_Uart PRIVATE rodos::rodos Sts1CobcSw_Hal Sts1CobcSw_Utility)
+
+add_program(UartWithWatchdog Uart.test.cpp WatchdogClear.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Uart PRIVATE rodos::rodos Sts1CobcSw_Hal Sts1CobcSw_Utility)
 
 add_program(Watchdog Watchdog.test.cpp)

--- a/Tests/HardwareTests/ThreadTests/CMakeLists.txt
+++ b/Tests/HardwareTests/ThreadTests/CMakeLists.txt
@@ -10,11 +10,7 @@ target_link_libraries(
     Sts1CobcSwTests_EduPowerManagement PRIVATE rodos::rodos Sts1CobcSw_Hal Sts1CobcSw_Edu
 )
 
-get_property(
-    thread_test_targets
-    DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-    PROPERTY BUILDSYSTEM_TARGETS
-)
+get_property(thread_test_targets DIRECTORY ${CMAKE_CURRENT_LIST_DIR} PROPERTY BUILDSYSTEM_TARGETS)
 
 # Add the top level project directory as include directory for all thread tests
 foreach(target IN LISTS thread_test_targets)

--- a/Tests/HardwareTests/WatchdogClear.test.cpp
+++ b/Tests/HardwareTests/WatchdogClear.test.cpp
@@ -1,6 +1,5 @@
 #include <Sts1CobcSw/Hal/GpioPin.hpp>
 #include <Sts1CobcSw/Hal/IoNames.hpp>
-#include <Sts1CobcSw/ThreadPriorities.hpp>
 
 #include <rodos_no_using_namespace.h>
 
@@ -14,7 +13,7 @@ static auto watchdogClearGpio = hal::GpioPin(hal::watchdogClearPin);
 class WatchdogClearTest : public RODOS::StaticThread<>
 {
 public:
-    WatchdogClearTest() : StaticThread("WatchdogClearTest", watchdogClearThreadPriority)
+    WatchdogClearTest() : StaticThread("WatchdogClearTest", 600)
     {
     }
 

--- a/Tests/HardwareTests/WatchdogClear.test.cpp
+++ b/Tests/HardwareTests/WatchdogClear.test.cpp
@@ -13,7 +13,7 @@ static auto watchdogClearGpio = hal::GpioPin(hal::watchdogClearPin);
 class WatchdogClearTest : public RODOS::StaticThread<>
 {
 public:
-    WatchdogClearTest() : StaticThread("WatchdogClearTest", 600)
+    WatchdogClearTest() : StaticThread("WatchdogClearTest", MAX_THREAD_PRIORITY)
     {
     }
 

--- a/Tests/HardwareTests/WatchdogClear.test.cpp
+++ b/Tests/HardwareTests/WatchdogClear.test.cpp
@@ -1,5 +1,6 @@
 #include <Sts1CobcSw/Hal/GpioPin.hpp>
 #include <Sts1CobcSw/Hal/IoNames.hpp>
+#include <Sts1CobcSw/ThreadPriorities.hpp>
 
 #include <rodos_no_using_namespace.h>
 
@@ -12,6 +13,13 @@ static auto watchdogClearGpio = hal::GpioPin(hal::watchdogClearPin);
 
 class WatchdogClearTest : public RODOS::StaticThread<>
 {
+public:
+    WatchdogClearTest() : StaticThread("WatchdogClearTest", watchdogClearThreadPriority)
+    {
+    }
+
+
+private:
     void init() override
     {
         led2Gpio.Direction(hal::PinDirection::out);

--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -33,9 +33,7 @@ add_program(Span Span.test.cpp)
 target_link_libraries(Sts1CobcSwTests_Span PRIVATE Catch2::Catch2WithMain Sts1CobcSw_Utility)
 
 get_property(
-    all_unit_test_targets
-    DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    PROPERTY BUILDSYSTEM_TARGETS
+    all_unit_test_targets DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY BUILDSYSTEM_TARGETS
 )
 add_custom_target(AllUnitTests) # Must be defined after getting all unit test targets
 add_dependencies(AllUnitTests ${all_unit_test_targets})

--- a/cmake/clang-tidy-cache.cmake
+++ b/cmake/clang-tidy-cache.cmake
@@ -3,8 +3,7 @@ if(CMAKE_CXX_CLANG_TIDY)
     if(CLANG_TIDY_CACHE_PATH)
         message("Found clang-tidy-cache")
         message("clang-tidy-cache directory : $ENV{CTCACHE_DIR}")
-        set(CLANG_TIDY_PATH
-            "${CLANG_TIDY_CACHE_PATH};${CMAKE_CXX_CLANG_TIDY}"
+        set(CLANG_TIDY_PATH "${CLANG_TIDY_CACHE_PATH};${CMAKE_CXX_CLANG_TIDY}"
             CACHE STRING "A combined command to run clang-tidy with caching wrapper"
         )
         set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_PATH}")

--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -1,15 +1,13 @@
 # ---- Variables ----
 
 # We use variables separate from what CTest uses, because those have customization issues
-set(COVERAGE_TRACE_COMMAND
-    lcov -c -q -o "${PROJECT_BINARY_DIR}/coverage.info" -d "${PROJECT_BINARY_DIR}" --include
-    "${PROJECT_SOURCE_DIR}/*"
+set(COVERAGE_TRACE_COMMAND lcov -c -q -o "${PROJECT_BINARY_DIR}/coverage.info" -d
+                           "${PROJECT_BINARY_DIR}" --include "${PROJECT_SOURCE_DIR}/*"
     CACHE STRING "; separated command to generate a trace for the 'coverage' target"
 )
 
-set(COVERAGE_HTML_COMMAND
-    genhtml --legend -f -q "${PROJECT_BINARY_DIR}/coverage.info" -p "${PROJECT_SOURCE_DIR}" -o
-    "${PROJECT_BINARY_DIR}/coverage_html"
+set(COVERAGE_HTML_COMMAND genhtml --legend -f -q "${PROJECT_BINARY_DIR}/coverage.info" -p
+                          "${PROJECT_SOURCE_DIR}" -o "${PROJECT_BINARY_DIR}/coverage_html"
     CACHE STRING "; separated command to generate an HTML report for the 'coverage' target"
 )
 

--- a/cmake/custom-commands.cmake
+++ b/cmake/custom-commands.cmake
@@ -2,16 +2,10 @@
 # propagated upwards, i.e., as soon as the function ends CMAKE_MODULE_PATH would be unset again.
 macro(find_package_and_notify package_name)
     get_property(
-        imported_targets_before
-        DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-        PROPERTY IMPORTED_TARGETS
+        imported_targets_before DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" PROPERTY IMPORTED_TARGETS
     )
     find_package(${package_name} REQUIRED)
-    get_property(
-        imported_targets
-        DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-        PROPERTY IMPORTED_TARGETS
-    )
+    get_property(imported_targets DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" PROPERTY IMPORTED_TARGETS)
     list(REMOVE_ITEM imported_targets ${imported_targets_before})
     foreach(target IN LISTS imported_targets)
         get_target_property(include_dirs ${target} INTERFACE_INCLUDE_DIRECTORIES)
@@ -20,8 +14,7 @@ macro(find_package_and_notify package_name)
 endmacro()
 
 function(find_rodos)
-    set(RODOS_PACKAGE_NAME
-        "rodos"
+    set(RODOS_PACKAGE_NAME "rodos"
         CACHE STRING "Name of the Rodos package used when calling find_package()"
     )
     find_package(${RODOS_PACKAGE_NAME} REQUIRED ${ARGN})
@@ -63,11 +56,7 @@ function(objcopy_target target_name)
 endfunction()
 
 function(all_targets_include_directories include_directories)
-    get_property(
-        target_names
-        DIRECTORY ${PROJECT_SOURCE_DIR}
-        PROPERTY BUILDSYSTEM_TARGETS
-    )
+    get_property(target_names DIRECTORY ${PROJECT_SOURCE_DIR} PROPERTY BUILDSYSTEM_TARGETS)
     message("Setting include directory to ${include_directories} for targets:")
     foreach(target IN LISTS target_names)
         message("- ${target}")

--- a/cmake/docs-ci.cmake
+++ b/cmake/docs-ci.cmake
@@ -13,18 +13,14 @@ set(src "${PROJECT_SOURCE_DIR}")
 set(mcss_SOURCE_DIR "${bin}/docs/.ci")
 if(NOT IS_DIRECTORY "${mcss_SOURCE_DIR}")
     file(MAKE_DIRECTORY "${mcss_SOURCE_DIR}")
-    file(
-        DOWNLOAD https://github.com/friendlyanon/m.css/releases/download/release-1/mcss.zip
-        "${mcss_SOURCE_DIR}/mcss.zip"
-        STATUS status
-        EXPECTED_MD5 00cd2757ebafb9bcba7f5d399b3bec7f
+    file(DOWNLOAD https://github.com/friendlyanon/m.css/releases/download/release-1/mcss.zip
+         "${mcss_SOURCE_DIR}/mcss.zip" STATUS status EXPECTED_MD5 00cd2757ebafb9bcba7f5d399b3bec7f
     )
     if(NOT status MATCHES "^0;")
         message(FATAL_ERROR "Download failed with ${status}")
     endif()
     execute_process(
-        COMMAND "${CMAKE_COMMAND}" -E tar xf mcss.zip
-        WORKING_DIRECTORY "${mcss_SOURCE_DIR}"
+        COMMAND "${CMAKE_COMMAND}" -E tar xf mcss.zip WORKING_DIRECTORY "${mcss_SOURCE_DIR}"
         RESULT_VARIABLE result
     )
     if(NOT result EQUAL "0")
@@ -63,38 +59,23 @@ endmacro()
 
 function(docs_project name)
     cmake_parse_arguments(PARSE_ARGV 1 "" "" "VERSION;DESCRIPTION;HOMEPAGE_URL" LANGUAGES)
-    set(PROJECT_NAME
-        "${name}"
-        PARENT_SCOPE
-    )
+    set(PROJECT_NAME "${name}" PARENT_SCOPE)
     if(DEFINED _VERSION)
-        set(PROJECT_VERSION
-            "${_VERSION}"
-            PARENT_SCOPE
-        )
+        set(PROJECT_VERSION "${_VERSION}" PARENT_SCOPE)
         string(REGEX MATCH "^[0-9]+(\\.[0-9]+)*" versions "${_VERSION}")
         string(REPLACE . ";" versions "${versions}")
         set(suffixes MAJOR MINOR PATCH TWEAK)
         while(NOT versions STREQUAL "" AND NOT suffixes STREQUAL "")
             list_pop_front(versions version)
             list_pop_front(suffixes suffix)
-            set("PROJECT_VERSION_${suffix}"
-                "${version}"
-                PARENT_SCOPE
-            )
+            set("PROJECT_VERSION_${suffix}" "${version}" PARENT_SCOPE)
         endwhile()
     endif()
     if(DEFINED _DESCRIPTION)
-        set(PROJECT_DESCRIPTION
-            "${_DESCRIPTION}"
-            PARENT_SCOPE
-        )
+        set(PROJECT_DESCRIPTION "${_DESCRIPTION}" PARENT_SCOPE)
     endif()
     if(DEFINED _HOMEPAGE_URL)
-        set(PROJECT_HOMEPAGE_URL
-            "${_HOMEPAGE_URL}"
-            PARENT_SCOPE
-        )
+        set(PROJECT_HOMEPAGE_URL "${_HOMEPAGE_URL}" PARENT_SCOPE)
     endif()
 endfunction()
 
@@ -117,8 +98,7 @@ set(config "${bin}/docs/conf.py")
 file(REMOVE_RECURSE "${out}/html" "${out}/xml")
 
 execute_process(
-    COMMAND "${Python3_EXECUTABLE}" "${mcss_script}" "${config}"
-    WORKING_DIRECTORY "${bin}/docs"
+    COMMAND "${Python3_EXECUTABLE}" "${mcss_script}" "${config}" WORKING_DIRECTORY "${bin}/docs"
     RESULT_VARIABLE result
 )
 if(NOT result EQUAL "0")

--- a/cmake/docs.cmake
+++ b/cmake/docs.cmake
@@ -20,8 +20,7 @@ find_package(Python3 3.6 REQUIRED)
 
 # ---- Declare documentation target ----
 
-set(DOXYGEN_OUTPUT_DIRECTORY
-    "${PROJECT_BINARY_DIR}/docs"
+set(DOXYGEN_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/docs"
     CACHE PATH "Path for the generated Doxygen documentation"
 )
 

--- a/cmake/folders.cmake
+++ b/cmake/folders.cmake
@@ -5,26 +5,14 @@ set_property(GLOBAL PROPERTY USE_FOLDERS YES)
 # ${name}Targets folder. If a target already has a folder assigned, then that target will be
 # skipped.
 function(add_folders name)
-    get_property(
-        targets
-        DIRECTORY
-        PROPERTY BUILDSYSTEM_TARGETS
-    )
+    get_property(targets DIRECTORY PROPERTY BUILDSYSTEM_TARGETS)
     foreach(target IN LISTS targets)
-        get_property(
-            folder
-            TARGET "${target}"
-            PROPERTY FOLDER
-        )
+        get_property(folder TARGET "${target}" PROPERTY FOLDER)
         if(DEFINED folder)
             continue()
         endif()
         set(folder Utility)
-        get_property(
-            type
-            TARGET "${target}"
-            PROPERTY TYPE
-        )
+        get_property(type TARGET "${target}" PROPERTY TYPE)
         if(NOT type STREQUAL "UTILITY")
             set(folder "${name}")
         endif()

--- a/cmake/format-cpp.cmake
+++ b/cmake/format-cpp.cmake
@@ -32,8 +32,7 @@ string(LENGTH "${CMAKE_SOURCE_DIR}/" path_prefix_length)
 foreach(file IN LISTS files)
     execute_process(
         COMMAND clang-format --style=file "${flag}" "${file}"
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-        RESULT_VARIABLE result ${args}
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" RESULT_VARIABLE result ${args}
     )
     if(NOT result EQUAL "0")
         message(FATAL_ERROR "'${file}': formatter returned with ${result}")

--- a/cmake/format.cmake
+++ b/cmake/format.cmake
@@ -5,14 +5,12 @@ endif()
 
 execute_process(
     COMMAND "${CMAKE_COMMAND}" "${fix_flag}" -P cmake/format-cpp.cmake
-    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-    RESULT_VARIABLE cpp_result
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}" RESULT_VARIABLE cpp_result
 )
 
 execute_process(
     COMMAND "${CMAKE_COMMAND}" "${fix_flag}" -P cmake/format-cmake.cmake
-    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
-    RESULT_VARIABLE cmake_result
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}" RESULT_VARIABLE cmake_result
 )
 
 if(NOT cpp_result EQUAL "0" OR NOT cmake_result EQUAL "0")

--- a/cmake/golden-tests.cmake
+++ b/cmake/golden-tests.cmake
@@ -27,8 +27,7 @@ macro(add_golden_test)
         add_custom_command(
             OUTPUT "${test_filename}.output"
             COMMAND bash "${CMAKE_CURRENT_SOURCE_DIR}/Scripts/TestRunner.sh"
-                    $<TARGET_FILE:${target_name}>
-            DEPENDS ${target_name} Scripts/TestRunner.sh
+                    $<TARGET_FILE:${target_name}> DEPENDS ${target_name} Scripts/TestRunner.sh
         )
         add_test(NAME ${test_filename}_Test
                  COMMAND diff "${test_filename}.output"

--- a/cmake/spell-targets.cmake
+++ b/cmake/spell-targets.cmake
@@ -1,7 +1,4 @@
-set(SPELL_COMMAND
-    codespell
-    CACHE STRING "Spell checker to use"
-)
+set(SPELL_COMMAND codespell CACHE STRING "Spell checker to use")
 
 add_custom_target(
     spell-check

--- a/cmake/spell.cmake
+++ b/cmake/spell.cmake
@@ -15,8 +15,7 @@ if(FIX)
 endif()
 
 execute_process(
-    COMMAND "${SPELL_COMMAND}" ${flag}
-    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    COMMAND "${SPELL_COMMAND}" ${flag} WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     RESULT_VARIABLE result
 )
 


### PR DESCRIPTION
Fixes #288 

Also sets `max_subgroups_hwrap = 3` in .cmake-format.py.