### PR TITLE
Set rfLatchupDisableGpioPin to output in all HW tests

### DIFF
--- a/Tests/HardwareTests/Crc32.test.cpp
+++ b/Tests/HardwareTests/Crc32.test.cpp
@@ -64,6 +64,9 @@ public:
 private:
     void init() override
     {
+#if HW_VERSION >= 27
+        rfLatchupDisableGpioPin.Direction(hal::PinDirection::out);
+#endif
     }
 
 

--- a/Tests/HardwareTests/DisableRfLatchupProtection.test.cpp
+++ b/Tests/HardwareTests/DisableRfLatchupProtection.test.cpp
@@ -11,6 +11,9 @@ class DisableRfLatchupProtectionTest : public RODOS::StaticThread<>
 {
     void init() override
     {
+#if HW_VERSION >= 27
+        rfLatchupDisableGpioPin.Direction(hal::PinDirection::out);
+#endif
     }
 
 

--- a/Tests/HardwareTests/EduCommands.test.cpp
+++ b/Tests/HardwareTests/EduCommands.test.cpp
@@ -41,6 +41,9 @@ public:
 private:
     void init() override
     {
+#if HW_VERSION >= 27
+        rfLatchupDisableGpioPin.Direction(hal::PinDirection::out);
+#endif
         edu::Initialize();
         auto const baudRate = 115'200;
         hal::Initialize(&uciUart, baudRate);

--- a/Tests/HardwareTests/Eps.test.cpp
+++ b/Tests/HardwareTests/Eps.test.cpp
@@ -24,6 +24,9 @@ public:
 private:
     void init() override
     {
+#if HW_VERSION >= 27
+        rfLatchupDisableGpioPin.Direction(hal::PinDirection::out);
+#endif
     }
 
 

--- a/Tests/HardwareTests/FileSystem.test.cpp
+++ b/Tests/HardwareTests/FileSystem.test.cpp
@@ -28,6 +28,9 @@ public:
 private:
     void init() override
     {
+#if HW_VERSION >= 27
+        rfLatchupDisableGpioPin.Direction(hal::PinDirection::out);
+#endif
         fs::deprecated::Initialize();
     }
 

--- a/Tests/HardwareTests/Flash.test.cpp
+++ b/Tests/HardwareTests/Flash.test.cpp
@@ -35,6 +35,9 @@ public:
 private:
     void init() override
     {
+#if HW_VERSION >= 27
+        rfLatchupDisableGpioPin.Direction(hal::PinDirection::out);
+#endif
         flash::Initialize();
     }
 

--- a/Tests/HardwareTests/Fram.test.cpp
+++ b/Tests/HardwareTests/Fram.test.cpp
@@ -46,6 +46,9 @@ public:
 private:
     void init() override
     {
+#if HW_VERSION >= 27
+        rfLatchupDisableGpioPin.Direction(hal::PinDirection::out);
+#endif
         fram::Initialize();
     }
 

--- a/Tests/HardwareTests/Gpio.test.cpp
+++ b/Tests/HardwareTests/Gpio.test.cpp
@@ -21,6 +21,9 @@ class GpioTest : public RODOS::StaticThread<>
 {
     void init() override
     {
+#if HW_VERSION >= 27
+        rfLatchupDisableGpioPin.Direction(hal::PinDirection::out);
+#endif
         for(auto & pin : pinsToTest)
         {
             pin.Direction(hal::PinDirection::out);

--- a/Tests/HardwareTests/MaxPower.test.cpp
+++ b/Tests/HardwareTests/MaxPower.test.cpp
@@ -106,6 +106,9 @@ public:
 private:
     void init() override
     {
+#if HW_VERSION >= 27
+        rfLatchupDisableGpioPin.Direction(hal::PinDirection::out);
+#endif
         auto const baudRate = 115'200;
         hal::Initialize(&uciUart, baudRate);
     }

--- a/Tests/HardwareTests/Rf.test.cpp
+++ b/Tests/HardwareTests/Rf.test.cpp
@@ -23,6 +23,9 @@ public:
 private:
     void init() override
     {
+#if HW_VERSION >= 27
+        rfLatchupDisableGpioPin.Direction(hal::PinDirection::out);
+#endif
     }
 
 

--- a/Tests/HardwareTests/ThreadTests/EduPowerManagement.test.cpp
+++ b/Tests/HardwareTests/ThreadTests/EduPowerManagement.test.cpp
@@ -29,6 +29,9 @@ public:
 private:
     void init() override
     {
+#if HW_VERSION >= 27
+        rfLatchupDisableGpioPin.Direction(hal::PinDirection::out);
+#endif
         edu::Initialize();
         eduUpdateGpioPin.Direction(hal::PinDirection::in);
         auto const baudRate = 115'200;

--- a/Tests/HardwareTests/Uart.test.cpp
+++ b/Tests/HardwareTests/Uart.test.cpp
@@ -41,6 +41,9 @@ class UartTest : public RODOS::StaticThread<>
 {
     void init() override
     {
+#if HW_VERSION >= 27
+        rfLatchupDisableGpioPin.Direction(hal::PinDirection::out);
+#endif
         auto uartBaudRate = 115'200U;
         hal::Initialize(&eduUart, uartBaudRate);
         hal::Initialize(&uciUart, uartBaudRate);

--- a/Tests/HardwareTests/Watchdog.test.cpp
+++ b/Tests/HardwareTests/Watchdog.test.cpp
@@ -15,6 +15,9 @@ class WatchdogTest : public RODOS::StaticThread<>
 {
     void init() override
     {
+#if HW_VERSION >= 27
+        rfLatchupDisableGpioPin.Direction(hal::PinDirection::out);
+#endif
         led1Gpio.Direction(hal::PinDirection::out);
     }
 

--- a/Tests/HardwareTests/WatchdogClear.test.cpp
+++ b/Tests/HardwareTests/WatchdogClear.test.cpp
@@ -23,6 +23,9 @@ public:
 private:
     void init() override
     {
+#if HW_VERSION >= 27
+        rfLatchupDisableGpioPin.Direction(hal::PinDirection::out);
+#endif
         led2Gpio.Direction(hal::PinDirection::out);
         watchdogClearGpio.Direction(hal::PinDirection::out);
     }


### PR DESCRIPTION
### Description

The pin for disabling the RF latch-up protection was correctly set to high or low in #300, but the direction was not set, so nothing really happened. This PR fixes this.
