### PR TITLE
Add extensions to devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "STS1 COBC Full",
+    "name": "STS1 COBC",
     "image": "tuwienspaceteam/sts1-cobc:1.8.0",
     "customizations": {
         "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,21 @@
     "customizations": {
         "vscode": {
             "extensions": [
+                "ms-dotnettools.vscode-dotnet-runtime",
                 "ms-vscode.cpptools",
-                "ms-vscode.cmake-tools",
+                "matepek.vscode-catch2-test-adapter",
                 "xaver.clang-format",
-                "mhutchie.git-graph"
+                "llvm-vs-code-extensions.vscode-clangd",
+                "twxs.cmake",
+                "josetr.cmake-language-support-vscode",
+                "ms-vscode.cmake-tools",
+                "cheshirekow.cmake-format",
+                "mhutchie.git-graph",
+                "eamodio.gitlens",
+                "LAK132.indent-to-bracket",
+                "valentjn.vscode-ltex",
+                "ionutvmi.path-autocomplete",
+                "Gruntfuggly.todo-tree"
             ]
         }
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,14 @@
 {
     "name": "STS1 COBC Full",
-    "image": "tuwienspaceteam/sts1-cobc:1.8.0"
+    "image": "tuwienspaceteam/sts1-cobc:1.8.0",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools",
+                "ms-vscode.cmake-tools",
+                "xaver.clang-format",
+                "mhutchie.git-graph"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
### Description

Every time we update the devcontainer to a new version, it needs to be rebuilt. That also means installing all extensions again, which is annoying even though it doesn't happen very often. Still, adding most extensions from my embedded profile which I shared with the other team members is quite convenient. I also shortened the devconainter name since it is shown in the status bar where space is precious.