### PR TITLE
Move Edu program status history to FRAM

### DIFF
--- a/Sts1CobcSw/CobcSoftware/EduProgramQueueThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/EduProgramQueueThread.cpp
@@ -6,6 +6,7 @@
 #include <Sts1CobcSw/Edu/ProgramQueue.hpp>
 #include <Sts1CobcSw/Edu/ProgramStatusHistory.hpp>
 #include <Sts1CobcSw/Edu/Types.hpp>
+#include <Sts1CobcSw/FramSections/RingArray.hpp>
 #include <Sts1CobcSw/ProgramId/ProgramId.hpp>  // IWYU pragma: keep
 #include <Sts1CobcSw/Utility/Debug.hpp>
 #include <Sts1CobcSw/Utility/Time.hpp>
@@ -15,7 +16,6 @@
 #include <strong_type/difference.hpp>
 #include <strong_type/type.hpp>
 
-#include <rodos/support/support-libs/ringbuffer.h>
 #include <rodos_no_using_namespace.h>
 
 #include <etl/vector.h>

--- a/Sts1CobcSw/CobcSoftware/EduProgramQueueThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/EduProgramQueueThread.cpp
@@ -136,7 +136,7 @@ private:
             }
             else
             {
-                edu::programStatusHistory.put(
+                edu::programStatusHistory.PushBack(
                     edu::ProgramStatusHistoryEntry{.programId = programId,
                                                    .startTime = startTime,
                                                    .status = edu::ProgramStatus::programRunning});

--- a/Sts1CobcSw/Edu/ProgramStatusHistory.cpp
+++ b/Sts1CobcSw/Edu/ProgramStatusHistory.cpp
@@ -8,9 +8,10 @@
 namespace sts1cobcsw::edu
 {
 constexpr auto programStatusHistorySection = framSections.Get<"eduProgramStatusHistory">();
-sts1cobcsw::
-    RingArray<ProgramStatusHistoryEntry, programStatusHistorySection, nProgramStatusHistoryEntries>
-        programStatusHistory;
+sts1cobcsw::RingArray<ProgramStatusHistoryEntry,
+                      programStatusHistorySection,
+                      nCachedProgramStatusHistoryEntries>
+    programStatusHistory;
 
 
 auto UpdateProgramStatusHistory(ProgramId programId, RealTime startTime, ProgramStatus newStatus)

--- a/Sts1CobcSw/Edu/ProgramStatusHistory.cpp
+++ b/Sts1CobcSw/Edu/ProgramStatusHistory.cpp
@@ -16,15 +16,10 @@ sts1cobcsw::RingArray<ProgramStatusHistoryEntry,
 auto UpdateProgramStatusHistory(ProgramId programId, RealTime startTime, ProgramStatus newStatus)
     -> void
 {
-    for(std::size_t i = 0; i < programStatusHistory.Size(); ++i)
-    {
-        auto entry = programStatusHistory.Get(i);
-        if(entry.startTime == startTime and entry.programId == programId)
-        {
-            entry.status = newStatus;
-            programStatusHistory.Set(i, entry);
-        }
-    }
+    programStatusHistory.FindAndReplace(
+        [&](ProgramStatusHistoryEntry const & entry) -> bool
+        { return entry.startTime == startTime && entry.programId == programId; },
+        ProgramStatusHistoryEntry{programId, startTime, newStatus});
 }
 
 

--- a/Sts1CobcSw/Edu/ProgramStatusHistory.cpp
+++ b/Sts1CobcSw/Edu/ProgramStatusHistory.cpp
@@ -17,8 +17,8 @@ auto UpdateProgramStatusHistory(ProgramId programId, RealTime startTime, Program
     -> void
 {
     programStatusHistory.FindAndReplace(
-        [&](ProgramStatusHistoryEntry const & entry) -> bool
-        { return entry.startTime == startTime && entry.programId == programId; },
+        [programId, startTime](auto const & entry) -> bool
+        { return entry.programId == programId and entry.startTime == startTime; },
         ProgramStatusHistoryEntry{programId, startTime, newStatus});
 }
 

--- a/Sts1CobcSw/Edu/ProgramStatusHistory.cpp
+++ b/Sts1CobcSw/Edu/ProgramStatusHistory.cpp
@@ -7,9 +7,8 @@
 
 namespace sts1cobcsw::edu
 {
-constexpr auto programStatusHistorySection = framSections.Get<"eduProgramStatusHistory">();
 sts1cobcsw::RingArray<ProgramStatusHistoryEntry,
-                      programStatusHistorySection,
+                      framSections.Get<"eduProgramStatusHistory">(),
                       nCachedProgramStatusHistoryEntries>
     programStatusHistory;
 

--- a/Sts1CobcSw/Edu/ProgramStatusHistory.cpp
+++ b/Sts1CobcSw/Edu/ProgramStatusHistory.cpp
@@ -1,4 +1,6 @@
 #include <Sts1CobcSw/Edu/ProgramStatusHistory.hpp>
+#include <Sts1CobcSw/FramSections/FramLayout.hpp>
+#include <Sts1CobcSw/FramSections/RingArray.hpp>
 
 #include <strong_type/equality.hpp>
 
@@ -6,6 +8,14 @@
 namespace sts1cobcsw::edu
 {
 RODOS::RingBuffer<ProgramStatusHistoryEntry, nProgramStatusHistoryEntries> programStatusHistory;
+
+
+// Start by defining an other variable, update methods, and when everything works remove `old`
+// programStatusHistory
+constexpr auto programStatusHistorySection = framSections.Get<"eduProgramStatusHistory">();
+sts1cobcsw::
+    RingArray<ProgramStatusHistoryEntry, programStatusHistorySection, nProgramStatusHistoryEntries>
+        framProgramStatusHistory;
 
 
 auto UpdateProgramStatusHistory(ProgramId programId, RealTime startTime, ProgramStatus newStatus)
@@ -19,6 +29,21 @@ auto UpdateProgramStatusHistory(ProgramId programId, RealTime startTime, Program
            and programStatusHistory.vals[i].programId == programId)
         {
             programStatusHistory.vals[i].status = newStatus;
+        }
+    }
+}
+
+auto UpdateFramProgramStatusHistory(ProgramId programId,
+                                    RealTime startTime,
+                                    ProgramStatus newStatus) -> void
+{
+    for(std::size_t i = 0; i < framProgramStatusHistory.Size(); ++i)
+    {
+        auto entry = framProgramStatusHistory.Get(i);
+        if(entry.startTime == startTime and entry.programId == programId)
+        {
+            entry.status = newStatus;
+            framProgramStatusHistory.Set(i, entry);
         }
     }
 }

--- a/Sts1CobcSw/Edu/ProgramStatusHistory.cpp
+++ b/Sts1CobcSw/Edu/ProgramStatusHistory.cpp
@@ -7,43 +7,22 @@
 
 namespace sts1cobcsw::edu
 {
-RODOS::RingBuffer<ProgramStatusHistoryEntry, nProgramStatusHistoryEntries> programStatusHistory;
-
-
-// Start by defining an other variable, update methods, and when everything works remove `old`
-// programStatusHistory
 constexpr auto programStatusHistorySection = framSections.Get<"eduProgramStatusHistory">();
 sts1cobcsw::
     RingArray<ProgramStatusHistoryEntry, programStatusHistorySection, nProgramStatusHistoryEntries>
-        framProgramStatusHistory;
+        programStatusHistory;
 
 
 auto UpdateProgramStatusHistory(ProgramId programId, RealTime startTime, ProgramStatus newStatus)
     -> void
 {
-    // TODO: Check that there is only one entry matching program/queue ID, or should it be the case
-    // by construction ?
-    for(std::uint32_t i = 0; i < programStatusHistory.occupiedCnt; ++i)
+    for(std::size_t i = 0; i < programStatusHistory.Size(); ++i)
     {
-        if(programStatusHistory.vals[i].startTime == startTime
-           and programStatusHistory.vals[i].programId == programId)
-        {
-            programStatusHistory.vals[i].status = newStatus;
-        }
-    }
-}
-
-auto UpdateFramProgramStatusHistory(ProgramId programId,
-                                    RealTime startTime,
-                                    ProgramStatus newStatus) -> void
-{
-    for(std::size_t i = 0; i < framProgramStatusHistory.Size(); ++i)
-    {
-        auto entry = framProgramStatusHistory.Get(i);
+        auto entry = programStatusHistory.Get(i);
         if(entry.startTime == startTime and entry.programId == programId)
         {
             entry.status = newStatus;
-            framProgramStatusHistory.Set(i, entry);
+            programStatusHistory.Set(i, entry);
         }
     }
 }

--- a/Sts1CobcSw/Edu/ProgramStatusHistory.hpp
+++ b/Sts1CobcSw/Edu/ProgramStatusHistory.hpp
@@ -61,7 +61,7 @@ inline constexpr auto nProgramStatusHistoryEntries =
 
 extern RingArray<ProgramStatusHistoryEntry,
                  framSections.template Get<"eduProgramStatusHistory">(),
-                 nProgramStatusHistoryEntries> // FIXME: Currently caching everything
+                 nProgramStatusHistoryEntries>  // FIXME: Currently caching everything
     programStatusHistory;
 
 auto UpdateProgramStatusHistory(ProgramId programId, RealTime startTime, ProgramStatus newStatus)

--- a/Sts1CobcSw/Edu/ProgramStatusHistory.hpp
+++ b/Sts1CobcSw/Edu/ProgramStatusHistory.hpp
@@ -3,13 +3,10 @@
 
 #include <Sts1CobcSw/FramSections/FramLayout.hpp>
 #include <Sts1CobcSw/FramSections/RingArray.hpp>
-#include <Sts1CobcSw/FramSections/Section.hpp>
 #include <Sts1CobcSw/FramSections/Subsections.hpp>
 #include <Sts1CobcSw/ProgramId/ProgramId.hpp>
 #include <Sts1CobcSw/Serial/Serial.hpp>
 #include <Sts1CobcSw/Utility/TimeTypes.hpp>
-
-#include <strong_type/type.hpp>
 
 // clang-format off
 #include <cstdint>
@@ -54,15 +51,14 @@ inline constexpr std::size_t serialSize<edu::ProgramStatusHistoryEntry> =
 
 namespace edu
 {
-// NOTE: Shouldn't this also account for indexes ?
-inline constexpr auto nProgramStatusHistoryEntries =
-    value_of(framSections.template Get<"eduProgramStatusHistory">().size)
-    / serialSize<ProgramStatusHistoryEntry>;
+inline constexpr auto nCachedProgramStatusHistoryEntries = 10;
 
 extern RingArray<ProgramStatusHistoryEntry,
                  framSections.template Get<"eduProgramStatusHistory">(),
-                 nProgramStatusHistoryEntries>  // FIXME: Currently caching everything
+                 nCachedProgramStatusHistoryEntries>
     programStatusHistory;
+
+inline constexpr auto nProgramStatusHistoryEntries = programStatusHistory.FramCapacity();
 
 auto UpdateProgramStatusHistory(ProgramId programId, RealTime startTime, ProgramStatus newStatus)
     -> void;

--- a/Sts1CobcSw/Edu/ProgramStatusHistory.hpp
+++ b/Sts1CobcSw/Edu/ProgramStatusHistory.hpp
@@ -13,8 +13,6 @@
 
 // clang-format off
 #include <cstdint>
-// ringbuffer.h does not include <cstdint> even though it requires it
-#include <rodos/support/support-libs/ringbuffer.h>
 // clang-format on
 
 #include <bit>
@@ -56,22 +54,15 @@ inline constexpr std::size_t serialSize<edu::ProgramStatusHistoryEntry> =
 
 namespace edu
 {
+// NOTE: Shouldn't this also account for indexes ?
 inline constexpr auto nProgramStatusHistoryEntries =
     value_of(framSections.template Get<"eduProgramStatusHistory">().size)
     / serialSize<ProgramStatusHistoryEntry>;
 
-extern RODOS::RingBuffer<ProgramStatusHistoryEntry, nProgramStatusHistoryEntries>
-    programStatusHistory;
-
-
 extern RingArray<ProgramStatusHistoryEntry,
                  framSections.template Get<"eduProgramStatusHistory">(),
-                 nProgramStatusHistoryEntries>
-    framProgramStatusHistory;
-
-auto UpdateFramProgramStatusHistory(ProgramId programId,
-                                    RealTime startTime,
-                                    ProgramStatus newStatus) -> void;
+                 nProgramStatusHistoryEntries> // FIXME: Currently caching everything
+    programStatusHistory;
 
 auto UpdateProgramStatusHistory(ProgramId programId, RealTime startTime, ProgramStatus newStatus)
     -> void;

--- a/Sts1CobcSw/Edu/ProgramStatusHistory.hpp
+++ b/Sts1CobcSw/Edu/ProgramStatusHistory.hpp
@@ -2,6 +2,7 @@
 
 
 #include <Sts1CobcSw/FramSections/FramLayout.hpp>
+#include <Sts1CobcSw/FramSections/RingArray.hpp>
 #include <Sts1CobcSw/FramSections/Section.hpp>
 #include <Sts1CobcSw/FramSections/Subsections.hpp>
 #include <Sts1CobcSw/ProgramId/ProgramId.hpp>
@@ -62,6 +63,15 @@ inline constexpr auto nProgramStatusHistoryEntries =
 extern RODOS::RingBuffer<ProgramStatusHistoryEntry, nProgramStatusHistoryEntries>
     programStatusHistory;
 
+
+extern RingArray<ProgramStatusHistoryEntry,
+                 framSections.template Get<"eduProgramStatusHistory">(),
+                 nProgramStatusHistoryEntries>
+    framProgramStatusHistory;
+
+auto UpdateFramProgramStatusHistory(ProgramId programId,
+                                    RealTime startTime,
+                                    ProgramStatus newStatus) -> void;
 
 auto UpdateProgramStatusHistory(ProgramId programId, RealTime startTime, ProgramStatus newStatus)
     -> void;

--- a/Sts1CobcSw/Edu/ProgramStatusHistory.hpp
+++ b/Sts1CobcSw/Edu/ProgramStatusHistory.hpp
@@ -8,12 +8,9 @@
 #include <Sts1CobcSw/Serial/Serial.hpp>
 #include <Sts1CobcSw/Utility/TimeTypes.hpp>
 
-// clang-format off
-#include <cstdint>
-// clang-format on
-
 #include <bit>
 #include <cstddef>
+#include <cstdint>
 
 
 namespace sts1cobcsw
@@ -57,8 +54,6 @@ extern RingArray<ProgramStatusHistoryEntry,
                  framSections.template Get<"eduProgramStatusHistory">(),
                  nCachedProgramStatusHistoryEntries>
     programStatusHistory;
-
-inline constexpr auto nProgramStatusHistoryEntries = programStatusHistory.FramCapacity();
 
 auto UpdateProgramStatusHistory(ProgramId programId, RealTime startTime, ProgramStatus newStatus)
     -> void;

--- a/Sts1CobcSw/FileSystem/LfsWrapper.cpp
+++ b/Sts1CobcSw/FileSystem/LfsWrapper.cpp
@@ -184,7 +184,7 @@ auto File::Read(void * buffer, std::size_t size) const -> Result<int>
     {
         return ErrorCode::unsupportedOperation;
     }
-    auto nReadBytes = lfs_file_read(&lfs, &lfsFile_, buffer, size);
+    auto nReadBytes = lfs_file_read(&lfs, &lfsFile_, buffer, static_cast<lfs_size_t>(size));
     if(nReadBytes >= 0)
     {
         return nReadBytes;
@@ -203,7 +203,7 @@ auto File::Write(void const * buffer, std::size_t size) -> Result<int>
     {
         return ErrorCode::unsupportedOperation;
     }
-    auto nWrittenBytes = lfs_file_write(&lfs, &lfsFile_, buffer, size);
+    auto nWrittenBytes = lfs_file_write(&lfs, &lfsFile_, buffer, static_cast<lfs_size_t>(size));
     if(nWrittenBytes >= 0)
     {
         return nWrittenBytes;

--- a/Sts1CobcSw/FramSections/RingArray.hpp
+++ b/Sts1CobcSw/FramSections/RingArray.hpp
@@ -39,16 +39,12 @@ public:
     [[nodiscard]] static constexpr auto FramCapacity() -> SizeType;
     [[nodiscard]] static constexpr auto CacheCapacity() -> SizeType;
     [[nodiscard]] static auto Size() -> SizeType;
-    // TODO: The cache should hold the latest elements. However, Set(0) currently writes to the
-    // first element of the cache and the FRAM ring buffer. Since the cache usually holds less
-    // elements than the FRAM ring buffer, Set(0) updates different entries in the cache and the
-    // FRAM ring buffer. We can ignore this because we assume that the cache and FRAM ring buffer
-    // are never used at the same time, but I am not sure if this is a good idea.
     [[nodiscard]] static auto Get(IndexType index) -> T;
     [[nodiscard]] static auto Front() -> T;
     [[nodiscard]] static auto Back() -> T;
     static auto Set(IndexType index, T const & t) -> void;
     static auto PushBack(T const & t) -> void;
+    // TODO: Test this function
     static auto FindAndReplace(std::predicate<T> auto predicate, T const & newData) -> void;
 
 

--- a/Sts1CobcSw/FramSections/RingArray.hpp
+++ b/Sts1CobcSw/FramSections/RingArray.hpp
@@ -31,20 +31,23 @@ class RingArray
 {
 public:
     using ValueType = T;
+    using IndexType = std::size_t;
+    using SizeType = std::size_t;
+
     static constexpr auto section = ringArraySection;
 
-    [[nodiscard]] static constexpr auto FramCapacity() -> std::size_t;
-    [[nodiscard]] static constexpr auto CacheCapacity() -> std::size_t;
-    [[nodiscard]] static auto Size() -> std::size_t;
+    [[nodiscard]] static constexpr auto FramCapacity() -> SizeType;
+    [[nodiscard]] static constexpr auto CacheCapacity() -> SizeType;
+    [[nodiscard]] static auto Size() -> SizeType;
     // TODO: The cache should hold the latest elements. However, Set(0) currently writes to the
     // first element of the cache and the FRAM ring buffer. Since the cache usually holds less
     // elements than the FRAM ring buffer, Set(0) updates different entries in the cache and the
     // FRAM ring buffer. We can ignore this because we assume that the cache and FRAM ring buffer
     // are never used at the same time, but I am not sure if this is a good idea.
-    [[nodiscard]] static auto Get(std::size_t index) -> T;
+    [[nodiscard]] static auto Get(IndexType index) -> T;
     [[nodiscard]] static auto Front() -> T;
     [[nodiscard]] static auto Back() -> T;
-    static auto Set(std::size_t index, T const & t) -> void;
+    static auto Set(IndexType index, T const & t) -> void;
     static auto PushBack(T const & t) -> void;
     static auto FindAndReplace(std::predicate<T> auto predicate, T const & newData) -> void;
 
@@ -69,17 +72,17 @@ private:
 
     using RingIndex = etl::cyclic_value<RingIndexType, 0, framCapacity>;
 
-    static inline auto iEnd = RingIndex{};
     static inline auto iBegin = RingIndex{};
+    static inline auto iEnd = RingIndex{};
     static inline auto cache = etl::circular_buffer<SerialBuffer<T>, nCachedElements>{};
     static inline auto semaphore = RODOS::Semaphore{};
 
-    [[nodiscard]] static auto DoSize() -> std::size_t;
-    [[nodiscard]] static auto DoGet(std::size_t index) -> T;
-    static auto DoSet(std::size_t index, T const & t) -> void;
+    [[nodiscard]] static auto DoSize() -> SizeType;
+    [[nodiscard]] static auto DoGet(IndexType index) -> T;
+    static auto DoSet(IndexType index, T const & t) -> void;
     static auto LoadIndexes() -> void;
     static auto StoreIndexes() -> void;
-    [[nodiscard]] static auto FramSize() -> std::size_t;
+    [[nodiscard]] static auto FramSize() -> SizeType;
     [[nodiscard]] static auto ReadElement(RingIndex index) -> T;
     static auto WriteElement(RingIndex index, T const & t) -> void;
 };

--- a/Sts1CobcSw/FramSections/RingArray.hpp
+++ b/Sts1CobcSw/FramSections/RingArray.hpp
@@ -17,6 +17,7 @@
 #include <etl/circular_buffer.h>
 #include <etl/cyclic_value.h>
 
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <span>
@@ -40,10 +41,7 @@ public:
     [[nodiscard]] static auto Back() -> T;
     static auto Set(std::size_t index, T const & t) -> void;
     static auto PushBack(T const & t) -> void;
-
-    template<typename Predicate>
-        requires std::predicate<Predicate, T>
-    static auto FindAndReplace(Predicate predicate, T const & newData) -> void;
+    static auto FindAndReplace(std::predicate<T> auto predicate, T const & newData) -> void;
 
 
 private:
@@ -72,7 +70,7 @@ private:
 
     static auto LoadIndexes() -> void;
     static auto StoreIndexes() -> void;
-    [[nodiscard]] static auto ComputeSize() -> std::size_t;
+    [[nodiscard]] static auto FramSize() -> std::size_t;
     [[nodiscard]] static auto ReadElement(RingIndex index) -> T;
     static auto WriteElement(RingIndex index, T const & t) -> void;
 };

--- a/Sts1CobcSw/FramSections/RingArray.hpp
+++ b/Sts1CobcSw/FramSections/RingArray.hpp
@@ -50,23 +50,24 @@ public:
 
 
 private:
+    using RingIndexType = strong::underlying_type_t<fram::Size>;
+
     static constexpr auto elementSize = fram::Size(serialSize<T>);
-    static constexpr auto indexesSize = fram::Size(3 * 2 * totalSerialSize<std::size_t>);
+    static constexpr auto indexesSize = fram::Size(3 * 2 * totalSerialSize<RingIndexType>);
     static constexpr auto subsections =
         Subsections<section,
                     SubsectionInfo<"indexes", indexesSize>,
                     SubsectionInfo<"array", section.size - indexesSize>>{};
     static constexpr auto persistentIndexes =
         PersistentVariables<subsections.template Get<"indexes">(),
-                            PersistentVariableInfo<"iBegin", std::size_t>,
-                            PersistentVariableInfo<"iEnd", std::size_t>>{};
+                            PersistentVariableInfo<"iBegin", RingIndexType>,
+                            PersistentVariableInfo<"iEnd", RingIndexType>>{};
     // We reduce the FRAM capacity by one to distinguish between an empty and a full ring. See
     // PushBack() for details.
     static constexpr auto framCapacity = subsections.template Get<"array">().size / elementSize - 1;
     static constexpr auto spiTimeout = elementSize < 300U ? 1 * ms : value_of(elementSize) * 3 * us;
 
-
-    using RingIndex = etl::cyclic_value<std::size_t, 0, framCapacity>;
+    using RingIndex = etl::cyclic_value<RingIndexType, 0, framCapacity>;
 
     static inline auto iEnd = RingIndex{};
     static inline auto iBegin = RingIndex{};

--- a/Sts1CobcSw/FramSections/RingArray.hpp
+++ b/Sts1CobcSw/FramSections/RingArray.hpp
@@ -63,10 +63,10 @@ private:
 
     using RingIndex = etl::cyclic_value<std::size_t, 0, framCapacity>;
 
-    static RingIndex iEnd;
-    static RingIndex iBegin;
-    static etl::circular_buffer<SerialBuffer<T>, nCachedElements> cache;
-    static RODOS::Semaphore semaphore;
+    static inline auto iEnd = RingIndex{};
+    static inline auto iBegin = RingIndex{};
+    static inline auto cache = etl::circular_buffer<SerialBuffer<T>, nCachedElements>{};
+    static inline auto semaphore = RODOS::Semaphore{};
 
     [[nodiscard]] static auto DoSize() -> std::size_t;
     static auto LoadIndexes() -> void;

--- a/Sts1CobcSw/FramSections/RingArray.hpp
+++ b/Sts1CobcSw/FramSections/RingArray.hpp
@@ -68,6 +68,7 @@ private:
     static etl::circular_buffer<SerialBuffer<T>, nCachedElements> cache;
     static RODOS::Semaphore semaphore;
 
+    [[nodiscard]] static auto DoSize() -> std::size_t;
     static auto LoadIndexes() -> void;
     static auto StoreIndexes() -> void;
     [[nodiscard]] static auto FramSize() -> std::size_t;

--- a/Sts1CobcSw/FramSections/RingArray.hpp
+++ b/Sts1CobcSw/FramSections/RingArray.hpp
@@ -74,6 +74,8 @@ private:
     static inline auto semaphore = RODOS::Semaphore{};
 
     [[nodiscard]] static auto DoSize() -> std::size_t;
+    [[nodiscard]] static auto DoGet(std::size_t index) -> T;
+    static auto DoSet(std::size_t index, T const & t) -> void;
     static auto LoadIndexes() -> void;
     static auto StoreIndexes() -> void;
     [[nodiscard]] static auto FramSize() -> std::size_t;

--- a/Sts1CobcSw/FramSections/RingArray.hpp
+++ b/Sts1CobcSw/FramSections/RingArray.hpp
@@ -41,6 +41,10 @@ public:
     static auto Set(std::size_t index, T const & t) -> void;
     static auto PushBack(T const & t) -> void;
 
+    template<typename Predicate>
+        requires std::predicate<Predicate, T>
+    static auto FindAndReplace(Predicate predicate, T const & newData) -> void;
+
 
 private:
     static constexpr auto elementSize = fram::Size(serialSize<T>);

--- a/Sts1CobcSw/FramSections/RingArray.hpp
+++ b/Sts1CobcSw/FramSections/RingArray.hpp
@@ -36,6 +36,11 @@ public:
     [[nodiscard]] static constexpr auto FramCapacity() -> std::size_t;
     [[nodiscard]] static constexpr auto CacheCapacity() -> std::size_t;
     [[nodiscard]] static auto Size() -> std::size_t;
+    // TODO: The cache should hold the latest elements. However, Set(0) currently writes to the
+    // first element of the cache and the FRAM ring buffer. Since the cache usually holds less
+    // elements than the FRAM ring buffer, Set(0) updates different entries in the cache and the
+    // FRAM ring buffer. We can ignore this because we assume that the cache and FRAM ring buffer
+    // are never used at the same time, but I am not sure if this is a good idea.
     [[nodiscard]] static auto Get(std::size_t index) -> T;
     [[nodiscard]] static auto Front() -> T;
     [[nodiscard]] static auto Back() -> T;

--- a/Sts1CobcSw/FramSections/RingArray.ipp
+++ b/Sts1CobcSw/FramSections/RingArray.ipp
@@ -130,9 +130,10 @@ template<typename T, Section ringArraySection, std::size_t nCachedElements>
 auto RingArray<T, ringArraySection, nCachedElements>::PushBack(T const & t) -> void
 {
     auto protector = RODOS::ScopeProtector(&semaphore);  // NOLINT(google-readability-casting)
+    // We always write to the cache
+    cache.push(Serialize(t));
     if(not framIsWorking.Load())
     {
-        cache.push(Serialize(t));
         return;
     }
     LoadIndexes();

--- a/Sts1CobcSw/FramSections/RingArray.ipp
+++ b/Sts1CobcSw/FramSections/RingArray.ipp
@@ -5,6 +5,8 @@
 #include <Sts1CobcSw/Utility/Debug.hpp>
 #include <Sts1CobcSw/Utility/Span.hpp>
 
+#include <concepts>
+
 
 namespace sts1cobcsw
 {
@@ -152,6 +154,23 @@ auto RingArray<T, ringArraySection, nCachedElements>::PushBack(T const & t) -> v
     StoreIndexes();
 }
 
+
+template<typename T, Section ringArraySection, std::size_t nCachedElements>
+    requires(serialSize<T> > 0)
+template<typename Predicate>
+    requires std::predicate<Predicate, T>
+auto RingArray<T, ringArraySection, nCachedElements>::FindAndReplace(Predicate predicate,
+                                                                     T const & newData) -> void
+{
+    auto protector = RODOS::ScopeProtector(&semaphore);  // NOLINT(google-readability-casting)
+    for(std::size_t index = 0; index < Size(); ++index)
+    {
+        if(predicate(Get(index)))
+        {
+            Set(index, newData);
+        }
+    }
+}
 
 template<typename T, Section ringArraySection, std::size_t nCachedElements>
     requires(serialSize<T> > 0)

--- a/Sts1CobcSw/FramSections/RingArray.ipp
+++ b/Sts1CobcSw/FramSections/RingArray.ipp
@@ -13,7 +13,7 @@ using fram::framIsWorking;
 
 template<typename T, Section ringArraySection, std::size_t nCachedElements>
     requires(serialSize<T> > 0)
-inline constexpr auto RingArray<T, ringArraySection, nCachedElements>::FramCapacity() -> std::size_t
+inline constexpr auto RingArray<T, ringArraySection, nCachedElements>::FramCapacity() -> SizeType
 {
     return framCapacity;
 }
@@ -21,8 +21,7 @@ inline constexpr auto RingArray<T, ringArraySection, nCachedElements>::FramCapac
 
 template<typename T, Section ringArraySection, std::size_t nCachedElements>
     requires(serialSize<T> > 0)
-inline constexpr auto RingArray<T, ringArraySection, nCachedElements>::CacheCapacity()
-    -> std::size_t
+inline constexpr auto RingArray<T, ringArraySection, nCachedElements>::CacheCapacity() -> SizeType
 {
     return nCachedElements;
 }
@@ -30,7 +29,7 @@ inline constexpr auto RingArray<T, ringArraySection, nCachedElements>::CacheCapa
 
 template<typename T, Section ringArraySection, std::size_t nCachedElements>
     requires(serialSize<T> > 0)
-auto RingArray<T, ringArraySection, nCachedElements>::Size() -> std::size_t
+auto RingArray<T, ringArraySection, nCachedElements>::Size() -> SizeType
 {
     auto protector = RODOS::ScopeProtector(&semaphore);  // NOLINT(google-readability-casting)
     return DoSize();
@@ -39,7 +38,7 @@ auto RingArray<T, ringArraySection, nCachedElements>::Size() -> std::size_t
 
 template<typename T, Section ringArraySection, std::size_t nCachedElements>
     requires(serialSize<T> > 0)
-auto RingArray<T, ringArraySection, nCachedElements>::Get(std::size_t index) -> T
+auto RingArray<T, ringArraySection, nCachedElements>::Get(IndexType index) -> T
 {
     auto protector = RODOS::ScopeProtector(&semaphore);  // NOLINT(google-readability-casting)
     return DoGet(index);
@@ -78,7 +77,7 @@ auto RingArray<T, ringArraySection, nCachedElements>::Back() -> T
 
 template<typename T, Section ringArraySection, std::size_t nCachedElements>
     requires(serialSize<T> > 0)
-auto RingArray<T, ringArraySection, nCachedElements>::Set(std::size_t index, T const & t) -> void
+auto RingArray<T, ringArraySection, nCachedElements>::Set(IndexType index, T const & t) -> void
 {
     auto protector = RODOS::ScopeProtector(&semaphore);  // NOLINT(google-readability-casting)
     DoSet(index, t);
@@ -116,7 +115,7 @@ auto RingArray<T, ringArraySection, nCachedElements>::FindAndReplace(
 {
     auto protector = RODOS::ScopeProtector(&semaphore);  // NOLINT(google-readability-casting)
     auto size = DoSize();
-    for(std::size_t index = 0; index < size; ++index)
+    for(IndexType index = 0; index < size; ++index)
     {
         if(predicate(DoGet(index)))
         {
@@ -128,7 +127,7 @@ auto RingArray<T, ringArraySection, nCachedElements>::FindAndReplace(
 
 template<typename T, Section ringArraySection, std::size_t nCachedElements>
     requires(serialSize<T> > 0)
-auto RingArray<T, ringArraySection, nCachedElements>::DoSize() -> std::size_t
+auto RingArray<T, ringArraySection, nCachedElements>::DoSize() -> SizeType
 {
     if(framIsWorking.Load())
     {
@@ -141,7 +140,7 @@ auto RingArray<T, ringArraySection, nCachedElements>::DoSize() -> std::size_t
 
 template<typename T, Section ringArraySection, std::size_t nCachedElements>
     requires(serialSize<T> > 0)
-auto RingArray<T, ringArraySection, nCachedElements>::DoGet(std::size_t index) -> T
+auto RingArray<T, ringArraySection, nCachedElements>::DoGet(IndexType index) -> T
 {
     auto size = DoSize();
     if(index >= size)
@@ -163,7 +162,7 @@ auto RingArray<T, ringArraySection, nCachedElements>::DoGet(std::size_t index) -
 
 template<typename T, Section ringArraySection, std::size_t nCachedElements>
     requires(serialSize<T> > 0)
-auto RingArray<T, ringArraySection, nCachedElements>::DoSet(std::size_t index, T const & t) -> void
+auto RingArray<T, ringArraySection, nCachedElements>::DoSet(IndexType index, T const & t) -> void
 {
     if(index >= cache.size())
     {
@@ -218,7 +217,7 @@ auto RingArray<T, ringArraySection, nCachedElements>::StoreIndexes() -> void
 // Compute the size of the FRAM ring buffer
 template<typename T, Section ringArraySection, std::size_t nCachedElements>
     requires(serialSize<T> > 0)
-auto RingArray<T, ringArraySection, nCachedElements>::FramSize() -> std::size_t
+auto RingArray<T, ringArraySection, nCachedElements>::FramSize() -> SizeType
 {
     if(iEnd.get() >= iBegin.get())
     {

--- a/Sts1CobcSw/FramSections/RingArray.ipp
+++ b/Sts1CobcSw/FramSections/RingArray.ipp
@@ -151,28 +151,6 @@ auto RingArray<T, ringArraySection, nCachedElements>::FindAndReplace(
     }
 }
 
-template<typename T, Section ringArraySection, std::size_t nCachedElements>
-    requires(serialSize<T> > 0)
-typename RingArray<T, ringArraySection, nCachedElements>::RingIndex
-    RingArray<T, ringArraySection, nCachedElements>::iEnd = {};
-
-
-template<typename T, Section ringArraySection, std::size_t nCachedElements>
-    requires(serialSize<T> > 0)
-typename RingArray<T, ringArraySection, nCachedElements>::RingIndex
-    RingArray<T, ringArraySection, nCachedElements>::iBegin = {};
-
-
-template<typename T, Section ringArraySection, std::size_t nCachedElements>
-    requires(serialSize<T> > 0)
-etl::circular_buffer<SerialBuffer<T>,
-                     nCachedElements> RingArray<T, ringArraySection, nCachedElements>::cache = {};
-
-
-template<typename T, Section ringArraySection, std::size_t nCachedElements>
-    requires(serialSize<T> > 0)
-RODOS::Semaphore RingArray<T, ringArraySection, nCachedElements>::semaphore = {};
-
 
 // Load the begin and end indexes from the FRAM
 template<typename T, Section ringArraySection, std::size_t nCachedElements>

--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -82,7 +82,7 @@ target_compile_options(Sts1CobcSwTests_EdacVariable PRIVATE -Wno-class-memaccess
 add_program(FramRingArray FramRingArray.test.cpp UnitTestThread.cpp)
 target_link_libraries(
     Sts1CobcSwTests_FramRingArray PRIVATE rodos::rodos Sts1CobcSw_FramSections Sts1CobcSw_Periphery
-                                          Sts1CobcSw_Serial
+                                          Sts1CobcSw_Serial Sts1CobcSw_Utility
 )
 add_test(NAME FramRingArray COMMAND Sts1CobcSwTests_FramRingArray)
 

--- a/Tests/UnitTests/FramRingArray.test.cpp
+++ b/Tests/UnitTests/FramRingArray.test.cpp
@@ -52,12 +52,11 @@ auto DeserializeFrom(void const * source, S * data) -> void const *;
 
 
 inline constexpr auto charSection1 =
-    sts1cobcsw::Section<fram::Address(0), fram::Size(3 * 2 * sizeof(std::size_t) + 4)>{};
+    sts1cobcsw::Section<fram::Address(0), fram::Size(3 * 2 * 4 + 4)>{};
 inline constexpr auto charSection2 =
-    sts1cobcsw::Section<charSection1.end, fram::Size(3 * 2 * sizeof(std::size_t) + 4)>{};
+    sts1cobcsw::Section<charSection1.end, fram::Size(3 * 2 * 4 + 4)>{};
 inline constexpr auto sSection =
-    sts1cobcsw::Section<charSection2.end,
-                        fram::Size(3 * 2 * sizeof(std::size_t) + 4 * totalSerialSize<S>)>{};
+    sts1cobcsw::Section<charSection2.end, fram::Size(3 * 2 * 4 + 4 * totalSerialSize<S>)>{};
 
 inline constexpr auto charRingArray1 = sts1cobcsw::RingArray<char, charSection1, 2>{};
 inline constexpr auto charRingArray2 = sts1cobcsw::RingArray<char, charSection2, 2>{};
@@ -85,9 +84,8 @@ auto RunUnitTest() -> void
 
     fram::ram::SetAllDoFunctions();
     fram::Initialize();
-    static constexpr auto charRingArray1StartAddress = 3 * 2 * sizeof(std::size_t);
-    static constexpr auto sRingArrayStartAddress =
-        value_of(charRingArray2.section.end) + 3 * 2 * sizeof(std::size_t);
+    static constexpr auto charRingArray1StartAddress = 3 * 2 * 4;
+    static constexpr auto sRingArrayStartAddress = value_of(charRingArray2.section.end) + 3 * 2 * 4;
 
     // SECTION("FRAM is working")
     {

--- a/Tests/UnitTests/FramRingArray.test.cpp
+++ b/Tests/UnitTests/FramRingArray.test.cpp
@@ -51,29 +51,32 @@ template<std::endian endianness>
 auto DeserializeFrom(void const * source, S * data) -> void const *;
 
 
-inline constexpr auto charSection =
+inline constexpr auto charSection1 =
     sts1cobcsw::Section<fram::Address(0), fram::Size(3 * 2 * sizeof(std::size_t) + 4)>{};
+inline constexpr auto charSection2 =
+    sts1cobcsw::Section<charSection1.end, fram::Size(3 * 2 * sizeof(std::size_t) + 4)>{};
 inline constexpr auto sSection =
-    sts1cobcsw::Section<charSection.end,
+    sts1cobcsw::Section<charSection2.end,
                         fram::Size(3 * 2 * sizeof(std::size_t) + 4 * totalSerialSize<S>)>{};
 
-inline constexpr auto charRingArray = sts1cobcsw::RingArray<char, charSection, 2>{};
+inline constexpr auto charRingArray1 = sts1cobcsw::RingArray<char, charSection1, 2>{};
+inline constexpr auto charRingArray2 = sts1cobcsw::RingArray<char, charSection2, 2>{};
 inline constexpr auto sRingArray = sts1cobcsw::RingArray<S, sSection, 2>{};
 
 
-static_assert(std::is_same_v<decltype(charRingArray)::ValueType, char>);
-static_assert(charRingArray.FramCapacity() == 3);
-static_assert(charRingArray.CacheCapacity() == 2);
-static_assert(charRingArray.section.begin == fram::Address(0));
-static_assert(charRingArray.section.size == fram::Size(28));
-static_assert(charRingArray.section.end == fram::Address(28));
+static_assert(std::is_same_v<decltype(charRingArray1)::ValueType, char>);
+static_assert(charRingArray1.FramCapacity() == 3);
+static_assert(charRingArray1.CacheCapacity() == 2);
+static_assert(charRingArray1.section.begin == fram::Address(0));
+static_assert(charRingArray1.section.size == fram::Size(28));
+static_assert(charRingArray1.section.end == fram::Address(28));
 
 static_assert(std::is_same_v<decltype(sRingArray)::ValueType, S>);
 static_assert(sRingArray.FramCapacity() == 3);
 static_assert(sRingArray.CacheCapacity() == 2);
-static_assert(sRingArray.section.begin == fram::Address(28));
+static_assert(sRingArray.section.begin == fram::Address(56));
 static_assert(sRingArray.section.size == fram::Size(52));
-static_assert(sRingArray.section.end == fram::Address(80));
+static_assert(sRingArray.section.end == fram::Address(108));
 
 
 auto RunUnitTest() -> void
@@ -82,83 +85,83 @@ auto RunUnitTest() -> void
 
     fram::ram::SetAllDoFunctions();
     fram::Initialize();
-    static constexpr auto charRingArrayStartAddress = 3 * 2 * sizeof(std::size_t);
+    static constexpr auto charRingArray1StartAddress = 3 * 2 * sizeof(std::size_t);
     static constexpr auto sRingArrayStartAddress =
-        value_of(charRingArray.section.end) + 3 * 2 * sizeof(std::size_t);
+        value_of(charRingArray2.section.end) + 3 * 2 * sizeof(std::size_t);
 
     // SECTION("FRAM is working")
     {
         memory.fill(0x00_b);
         fram::framIsWorking.Store(true);
 
-        Require(charRingArray.Size() == 0);
+        Require(charRingArray1.Size() == 0);
 
         // Trying to set an element in an empty ring prints a debug message and does not set
         // anything
-        charRingArray.Set(0, 11);
+        charRingArray1.Set(0, 11);
         Require(std::all_of(memory.begin(), memory.end(), [](auto x) { return x == 0_b; }));
 
-        charRingArray.PushBack(11);
-        Require(charRingArray.Size() == 1);
-        Require(charRingArray.Front() == 11);
-        Require(charRingArray.Back() == 11);
+        charRingArray1.PushBack(11);
+        Require(charRingArray1.Size() == 1);
+        Require(charRingArray1.Front() == 11);
+        Require(charRingArray1.Back() == 11);
 
-        charRingArray.PushBack(12);
-        Require(charRingArray.Size() == 2);
-        Require(charRingArray.Front() == 11);
-        Require(charRingArray.Back() == 12);
+        charRingArray1.PushBack(12);
+        Require(charRingArray1.Size() == 2);
+        Require(charRingArray1.Front() == 11);
+        Require(charRingArray1.Back() == 12);
 
-        charRingArray.PushBack(13);
-        Require(charRingArray.Size() == 3);
-        Require(charRingArray.Front() == 11);
-        Require(charRingArray.Back() == 13);
-        Require(charRingArray.Get(0) == 11);
-        Require(charRingArray.Get(1) == 12);
-        Require(charRingArray.Get(2) == 13);
+        charRingArray1.PushBack(13);
+        Require(charRingArray1.Size() == 3);
+        Require(charRingArray1.Front() == 11);
+        Require(charRingArray1.Back() == 13);
+        Require(charRingArray1.Get(0) == 11);
+        Require(charRingArray1.Get(1) == 12);
+        Require(charRingArray1.Get(2) == 13);
 
         // PushBack() writes to memory
-        Require(fram::ram::memory[charRingArrayStartAddress + 0] == 11_b);
-        Require(fram::ram::memory[charRingArrayStartAddress + 1] == 12_b);
-        Require(fram::ram::memory[charRingArrayStartAddress + 2] == 13_b);
+        Require(fram::ram::memory[charRingArray1StartAddress + 0] == 11_b);
+        Require(fram::ram::memory[charRingArray1StartAddress + 1] == 12_b);
+        Require(fram::ram::memory[charRingArray1StartAddress + 2] == 13_b);
 
         // When pushing to a full ring, the size stays the same and the oldest element is lost
-        charRingArray.PushBack(14);
-        Require(charRingArray.Size() == 3);
-        Require(charRingArray.Front() == 12);
-        Require(charRingArray.Back() == 14);
+        charRingArray1.PushBack(14);
+        Require(charRingArray1.Size() == 3);
+        Require(charRingArray1.Front() == 12);
+        Require(charRingArray1.Back() == 14);
 
         // Only the (size + 2)th element overwrites the first one in memory because we keep a gap of
         // one between begin and end indexes
-        charRingArray.PushBack(15);
-        Require(charRingArray.Size() == 3);
-        Require(charRingArray.Front() == 13);
-        Require(charRingArray.Back() == 15);
-        Require(fram::ram::memory[charRingArrayStartAddress + 0] == 15_b);
-        Require(fram::ram::memory[charRingArrayStartAddress + 1] == 12_b);
-        Require(fram::ram::memory[charRingArrayStartAddress + 2] == 13_b);
-        Require(fram::ram::memory[charRingArrayStartAddress + 3] == 14_b);
+        charRingArray1.PushBack(15);
+        Require(charRingArray1.Size() == 3);
+        Require(charRingArray1.Front() == 13);
+        Require(charRingArray1.Back() == 15);
+        Require(fram::ram::memory[charRingArray1StartAddress + 0] == 15_b);
+        Require(fram::ram::memory[charRingArray1StartAddress + 1] == 12_b);
+        Require(fram::ram::memory[charRingArray1StartAddress + 2] == 13_b);
+        Require(fram::ram::memory[charRingArray1StartAddress + 3] == 14_b);
 
         // Set() writes to memory
-        charRingArray.Set(0, 21);
-        charRingArray.Set(1, 22);
+        charRingArray1.Set(0, 21);
+        charRingArray1.Set(1, 22);
         // Set() with an out-of-bounds index for the cache prints a debug message and does not write
         // to the cache
-        charRingArray.Set(2, 23);
-        Require(charRingArray.Get(0) == 21);
-        Require(charRingArray.Get(1) == 22);
-        Require(charRingArray.Get(2) == 23);
-        Require(fram::ram::memory[charRingArrayStartAddress + 0] == 23_b);
-        Require(fram::ram::memory[charRingArrayStartAddress + 1] == 12_b);
-        Require(fram::ram::memory[charRingArrayStartAddress + 2] == 21_b);
-        Require(fram::ram::memory[charRingArrayStartAddress + 3] == 22_b);
+        charRingArray1.Set(2, 23);
+        Require(charRingArray1.Get(0) == 21);
+        Require(charRingArray1.Get(1) == 22);
+        Require(charRingArray1.Get(2) == 23);
+        Require(fram::ram::memory[charRingArray1StartAddress + 0] == 23_b);
+        Require(fram::ram::memory[charRingArray1StartAddress + 1] == 12_b);
+        Require(fram::ram::memory[charRingArray1StartAddress + 2] == 21_b);
+        Require(fram::ram::memory[charRingArray1StartAddress + 3] == 22_b);
 
         // Get() with out-of-bounds index prints a debug message and returns the last element
-        Require(charRingArray.Get(17) == 23);
+        Require(charRingArray1.Get(17) == 23);
         // Set() with out-of-bounds index prints a debug message and does not set anything
-        charRingArray.Set(17, 0);
-        Require(charRingArray.Get(0) == 21);
-        Require(charRingArray.Get(1) == 22);
-        Require(charRingArray.Get(2) == 23);
+        charRingArray1.Set(17, 0);
+        Require(charRingArray1.Get(0) == 21);
+        Require(charRingArray1.Get(1) == 22);
+        Require(charRingArray1.Get(2) == 23);
     }
 
     // SECTION("FRAM is not working")
@@ -166,47 +169,52 @@ auto RunUnitTest() -> void
         memory.fill(0x00_b);
         fram::framIsWorking.Store(false);
 
-        Require(charRingArray.Size() == 0);
+        // Even though we reset the FRAM memory to zero, the cached values are still there
+        Require(charRingArray1.Size() == charRingArray1.CacheCapacity());
+        Require(charRingArray1.Get(0) == 21);
+        Require(charRingArray1.Get(1) == 22);
+
+        Require(charRingArray2.Size() == 0);
         // Trying to set an element in an empty ring prints a debug message
-        charRingArray.Set(0, 11);
+        charRingArray2.Set(0, 11);
 
-        charRingArray.PushBack(11);
-        Require(charRingArray.Size() == 1);
-        Require(charRingArray.Front() == 11);
-        Require(charRingArray.Back() == 11);
+        charRingArray2.PushBack(11);
+        Require(charRingArray2.Size() == 1);
+        Require(charRingArray2.Front() == 11);
+        Require(charRingArray2.Back() == 11);
 
-        charRingArray.PushBack(12);
-        Require(charRingArray.Size() == 2);
-        Require(charRingArray.Front() == 11);
-        Require(charRingArray.Back() == 12);
+        charRingArray2.PushBack(12);
+        Require(charRingArray2.Size() == 2);
+        Require(charRingArray2.Front() == 11);
+        Require(charRingArray2.Back() == 12);
 
-        Require(charRingArray.Get(0) == 11);
-        Require(charRingArray.Get(1) == 12);
+        Require(charRingArray2.Get(0) == 11);
+        Require(charRingArray2.Get(1) == 12);
 
         // PushBack() does not write to memory
-        Require(fram::ram::memory[charRingArrayStartAddress + 0] == 0_b);
-        Require(fram::ram::memory[charRingArrayStartAddress + 1] == 0_b);
+        Require(fram::ram::memory[charRingArray1StartAddress + 0] == 0_b);
+        Require(fram::ram::memory[charRingArray1StartAddress + 1] == 0_b);
 
         // When pushing to a full ring, the size stays the same and the oldest element is lost
-        charRingArray.PushBack(13);
-        Require(charRingArray.Size() == 2);
-        Require(charRingArray.Front() == 12);
-        Require(charRingArray.Back() == 13);
+        charRingArray2.PushBack(13);
+        Require(charRingArray2.Size() == 2);
+        Require(charRingArray2.Front() == 12);
+        Require(charRingArray2.Back() == 13);
 
         // Set() does not write to memory
-        charRingArray.Set(0, 21);
-        charRingArray.Set(1, 22);
-        Require(charRingArray.Get(0) == 21);
-        Require(charRingArray.Get(1) == 22);
-        Require(fram::ram::memory[charRingArrayStartAddress + 0] == 0_b);
-        Require(fram::ram::memory[charRingArrayStartAddress + 1] == 0_b);
+        charRingArray2.Set(0, 21);
+        charRingArray2.Set(1, 22);
+        Require(charRingArray2.Get(0) == 21);
+        Require(charRingArray2.Get(1) == 22);
+        Require(fram::ram::memory[charRingArray1StartAddress + 0] == 0_b);
+        Require(fram::ram::memory[charRingArray1StartAddress + 1] == 0_b);
 
         // Get() with out-of-bounds index prints a debug message and returns the last element
-        Require(charRingArray.Get(17) == 22);
+        Require(charRingArray2.Get(17) == 22);
         // Set() with out-of-bounds index prints a debug message and does not set anything
-        charRingArray.Set(17, 0);
-        Require(charRingArray.Get(0) == 21);
-        Require(charRingArray.Get(1) == 22);
+        charRingArray2.Set(17, 0);
+        Require(charRingArray2.Get(0) == 21);
+        Require(charRingArray2.Get(1) == 22);
     }
 
     // SECTION("RingArray of custom type")

--- a/Tests/UnitTests/FramRingArray.test.cpp
+++ b/Tests/UnitTests/FramRingArray.test.cpp
@@ -1,15 +1,12 @@
 #include <Tests/UnitTests/UnitTestThread.hpp>
 
-#include <Sts1CobcSw/Edu/ProgramStatusHistory.hpp>
 #include <Sts1CobcSw/FramSections/RingArray.hpp>
 #include <Sts1CobcSw/FramSections/Section.hpp>
 #include <Sts1CobcSw/Periphery/Fram.hpp>
 #include <Sts1CobcSw/Periphery/FramMock.hpp>
-#include <Sts1CobcSw/ProgramId/ProgramId.hpp>
 #include <Sts1CobcSw/Serial/Byte.hpp>
 #include <Sts1CobcSw/Serial/Serial.hpp>
 #include <Sts1CobcSw/Utility/ErrorDetectionAndCorrection.hpp>
-#include <Sts1CobcSw/Utility/TimeTypes.hpp>
 
 #include <strong_type/equality.hpp>
 #include <strong_type/type.hpp>
@@ -24,19 +21,21 @@
 
 namespace fram = sts1cobcsw::fram;
 using sts1cobcsw::operator""_b;  // NOLINT(misc-unused-using-decls)
+using sts1cobcsw::totalSerialSize;
+
 
 struct S
 {
     std::uint16_t u16 = 0;
     std::int32_t i32 = 0;
     std::uint8_t u8 = 0;
+
+    friend auto operator==(S const & lhs, S const & rhs) -> bool
+    {
+        return (lhs.i32 == rhs.i32) and (lhs.u16 == rhs.u16) and (lhs.u8 == rhs.u8);
+    }
 };
 
-// NOLINTNEXTLINE(modernize-use-trailing-return-type)
-bool operator==(S const & lhs, S const & rhs)
-{
-    return ((lhs.i32 == rhs.i32) and (lhs.u16 == rhs.u16) and (lhs.u8 and rhs.u8));
-}
 
 namespace sts1cobcsw
 {
@@ -45,51 +44,36 @@ constexpr std::size_t serialSize<S> =
     totalSerialSize<decltype(S::u16), decltype(S::i32), decltype(S::u8)>;
 }
 
-template<std::endian endianness>
-auto SerializeTo(void * destination, S const & data) -> void *
-{
-    destination = sts1cobcsw::SerializeTo<endianness>(destination, data.u16);
-    destination = sts1cobcsw::SerializeTo<endianness>(destination, data.i32);
-    destination = sts1cobcsw::SerializeTo<endianness>(destination, data.u8);
-    return destination;
-}
 
 template<std::endian endianness>
-auto DeserializeFrom(void const * source, S * data) -> void const *
-{
-    source = sts1cobcsw::DeserializeFrom<endianness>(source, &(data->u16));
-    source = sts1cobcsw::DeserializeFrom<endianness>(source, &(data->i32));
-    source = sts1cobcsw::DeserializeFrom<endianness>(source, &(data->u8));
-    return source;
-}
+auto SerializeTo(void * destination, S const & data) -> void *;
+template<std::endian endianness>
+auto DeserializeFrom(void const * source, S * data) -> void const *;
 
 
-inline constexpr auto section =
+inline constexpr auto charSection =
     sts1cobcsw::Section<fram::Address(0), fram::Size(3 * 2 * sizeof(std::size_t) + 4)>{};
+inline constexpr auto sSection =
+    sts1cobcsw::Section<charSection.end,
+                        fram::Size(3 * 2 * sizeof(std::size_t) + 4 * totalSerialSize<S>)>{};
 
-inline constexpr auto customTypeSection =
-    sts1cobcsw::Section<fram::Address(3 * 2 * sizeof(std::size_t) + 4),
-                        fram::Size(3 * 2 * sizeof(std::size_t) + sts1cobcsw::serialSize<S> * 4)>{};
-
-inline constexpr auto charRingArray = sts1cobcsw::RingArray<char, section, 2>{};
-inline constexpr auto sRingArray = sts1cobcsw::RingArray<S, customTypeSection, 2>{};
+inline constexpr auto charRingArray = sts1cobcsw::RingArray<char, charSection, 2>{};
+inline constexpr auto sRingArray = sts1cobcsw::RingArray<S, sSection, 2>{};
 
 
 static_assert(std::is_same_v<decltype(charRingArray)::ValueType, char>);
 static_assert(charRingArray.FramCapacity() == 3);
 static_assert(charRingArray.CacheCapacity() == 2);
 static_assert(charRingArray.section.begin == fram::Address(0));
-static_assert(charRingArray.section.end == fram::Address(28));
 static_assert(charRingArray.section.size == fram::Size(28));
+static_assert(charRingArray.section.end == fram::Address(28));
 
 static_assert(std::is_same_v<decltype(sRingArray)::ValueType, S>);
 static_assert(sRingArray.FramCapacity() == 3);
 static_assert(sRingArray.CacheCapacity() == 2);
 static_assert(sRingArray.section.begin == fram::Address(28));
-static_assert(sRingArray.section.end
-              == fram::Address(28 + 3 * 2 * sizeof(size_t) + 4 * sts1cobcsw::serialSize<S>));
-static_assert(sRingArray.section.size
-              == fram::Size(3 * 2 * sizeof(size_t) + 4 * sts1cobcsw::serialSize<S>));
+static_assert(sRingArray.section.size == fram::Size(52));
+static_assert(sRingArray.section.end == fram::Address(80));
 
 
 auto RunUnitTest() -> void
@@ -98,10 +82,9 @@ auto RunUnitTest() -> void
 
     fram::ram::SetAllDoFunctions();
     fram::Initialize();
-    static constexpr auto ringArrayStartAddress = 3 * 2 * sizeof(std::size_t);
+    static constexpr auto charRingArrayStartAddress = 3 * 2 * sizeof(std::size_t);
     static constexpr auto sRingArrayStartAddress =
-        3 * 2 * sizeof(std::size_t) + 4 + 3 * 2 * sizeof(std::size_t);
-
+        value_of(charRingArray.section.end) + 3 * 2 * sizeof(std::size_t);
 
     // SECTION("FRAM is working")
     {
@@ -133,10 +116,10 @@ auto RunUnitTest() -> void
         Require(charRingArray.Get(1) == 12);
         Require(charRingArray.Get(2) == 13);
 
-        // PushBack writes to memory
-        Require(fram::ram::memory[ringArrayStartAddress + 0] == 11_b);
-        Require(fram::ram::memory[ringArrayStartAddress + 1] == 12_b);
-        Require(fram::ram::memory[ringArrayStartAddress + 2] == 13_b);
+        // PushBack() writes to memory
+        Require(fram::ram::memory[charRingArrayStartAddress + 0] == 11_b);
+        Require(fram::ram::memory[charRingArrayStartAddress + 1] == 12_b);
+        Require(fram::ram::memory[charRingArrayStartAddress + 2] == 13_b);
 
         // When pushing to a full ring, the size stays the same and the oldest element is lost
         charRingArray.PushBack(14);
@@ -150,10 +133,10 @@ auto RunUnitTest() -> void
         Require(charRingArray.Size() == 3);
         Require(charRingArray.Front() == 13);
         Require(charRingArray.Back() == 15);
-        Require(fram::ram::memory[ringArrayStartAddress + 0] == 15_b);
-        Require(fram::ram::memory[ringArrayStartAddress + 1] == 12_b);
-        Require(fram::ram::memory[ringArrayStartAddress + 2] == 13_b);
-        Require(fram::ram::memory[ringArrayStartAddress + 3] == 14_b);
+        Require(fram::ram::memory[charRingArrayStartAddress + 0] == 15_b);
+        Require(fram::ram::memory[charRingArrayStartAddress + 1] == 12_b);
+        Require(fram::ram::memory[charRingArrayStartAddress + 2] == 13_b);
+        Require(fram::ram::memory[charRingArrayStartAddress + 3] == 14_b);
 
         // Set() writes to memory
         charRingArray.Set(0, 21);
@@ -162,10 +145,10 @@ auto RunUnitTest() -> void
         Require(charRingArray.Get(0) == 21);
         Require(charRingArray.Get(1) == 22);
         Require(charRingArray.Get(2) == 23);
-        Require(fram::ram::memory[ringArrayStartAddress + 0] == 23_b);
-        Require(fram::ram::memory[ringArrayStartAddress + 1] == 12_b);
-        Require(fram::ram::memory[ringArrayStartAddress + 2] == 21_b);
-        Require(fram::ram::memory[ringArrayStartAddress + 3] == 22_b);
+        Require(fram::ram::memory[charRingArrayStartAddress + 0] == 23_b);
+        Require(fram::ram::memory[charRingArrayStartAddress + 1] == 12_b);
+        Require(fram::ram::memory[charRingArrayStartAddress + 2] == 21_b);
+        Require(fram::ram::memory[charRingArrayStartAddress + 3] == 22_b);
 
         // Get() with out-of-bounds index prints a debug message and returns the last element
         Require(charRingArray.Get(17) == 23);
@@ -198,9 +181,9 @@ auto RunUnitTest() -> void
         Require(charRingArray.Get(0) == 11);
         Require(charRingArray.Get(1) == 12);
 
-        // PushBack does not write to memory
-        Require(fram::ram::memory[ringArrayStartAddress + 0] == 0_b);
-        Require(fram::ram::memory[ringArrayStartAddress + 1] == 0_b);
+        // PushBack() does not write to memory
+        Require(fram::ram::memory[charRingArrayStartAddress + 0] == 0_b);
+        Require(fram::ram::memory[charRingArrayStartAddress + 1] == 0_b);
 
         // When pushing to a full ring, the size stays the same and the oldest element is lost
         charRingArray.PushBack(13);
@@ -213,8 +196,8 @@ auto RunUnitTest() -> void
         charRingArray.Set(1, 22);
         Require(charRingArray.Get(0) == 21);
         Require(charRingArray.Get(1) == 22);
-        Require(fram::ram::memory[ringArrayStartAddress + 0] == 0_b);
-        Require(fram::ram::memory[ringArrayStartAddress + 1] == 0_b);
+        Require(fram::ram::memory[charRingArrayStartAddress + 0] == 0_b);
+        Require(fram::ram::memory[charRingArrayStartAddress + 1] == 0_b);
 
         // Get() with out-of-bounds index prints a debug message and returns the last element
         Require(charRingArray.Get(17) == 22);
@@ -224,21 +207,10 @@ auto RunUnitTest() -> void
         Require(charRingArray.Get(1) == 22);
     }
 
-
-    // SECTION("ProgramStatusHistoryEntry test")
+    // SECTION("RingArray of custom type")
     {
-        using sts1cobcsw::serialSize;
-        using sts1cobcsw::edu::ProgramStatusHistoryEntry;
-
-        using sts1cobcsw::ProgramId;
-        using sts1cobcsw::RealTime;
-        using sts1cobcsw::edu::ProgramStatus;
-
-
         memory.fill(0x00_b);
         fram::framIsWorking.Store(true);
-
-        Require(sRingArray.Size() == 0);
 
         auto s1 = S{.u16 = 1, .i32 = 1, .u8 = 1};
         auto s2 = S{.u16 = 2, .i32 = 2, .u8 = 2};
@@ -261,7 +233,6 @@ auto RunUnitTest() -> void
         Require(sRingArray.Front() == s1);
         Require(sRingArray.Back() == s1);
 
-        // programStatusHistory.PushBack(entry2);
         sRingArray.PushBack(s2);
         Require(sRingArray.Size() == 2);
         Require(sRingArray.Front() == s1);
@@ -276,7 +247,7 @@ auto RunUnitTest() -> void
         Require(sRingArray.Get(1) == s2);
         Require(sRingArray.Get(2) == s3);
 
-        // PushBack writes to memory
+        // PushBack() writes to memory
         Require(fram::ram::memory[sRingArrayStartAddress + 0] == 1_b);
         Require(fram::ram::memory[sRingArrayStartAddress + sizeof(S::u16)] == 1_b);
         Require(fram::ram::memory[sRingArrayStartAddress + sizeof(S::u16) + sizeof(S::i32)] == 1_b);
@@ -303,9 +274,9 @@ auto RunUnitTest() -> void
         Require(sRingArray.Get(2) == s8);
 
         Require(fram::ram::memory[sRingArrayStartAddress + 0] == 8_b);
-        Require(fram::ram::memory[sRingArrayStartAddress + serialSize<S>] == 2_b);
-        Require(fram::ram::memory[sRingArrayStartAddress + 2 * serialSize<S>] == 6_b);
-        Require(fram::ram::memory[sRingArrayStartAddress + 3 * serialSize<S>] == 7_b);
+        Require(fram::ram::memory[sRingArrayStartAddress + totalSerialSize<S>] == 2_b);
+        Require(fram::ram::memory[sRingArrayStartAddress + 2 * totalSerialSize<S>] == 6_b);
+        Require(fram::ram::memory[sRingArrayStartAddress + 3 * totalSerialSize<S>] == 7_b);
 
         // Get() with out-of-bounds index prints a debug message and returns the last element
         Require(sRingArray.Get(17) == s8);
@@ -315,4 +286,24 @@ auto RunUnitTest() -> void
         Require(sRingArray.Get(1) == s7);
         Require(sRingArray.Get(2) == s8);
     }
+}
+
+
+template<std::endian endianness>
+auto SerializeTo(void * destination, S const & data) -> void *
+{
+    destination = sts1cobcsw::SerializeTo<endianness>(destination, data.u16);
+    destination = sts1cobcsw::SerializeTo<endianness>(destination, data.i32);
+    destination = sts1cobcsw::SerializeTo<endianness>(destination, data.u8);
+    return destination;
+}
+
+
+template<std::endian endianness>
+auto DeserializeFrom(void const * source, S * data) -> void const *
+{
+    source = sts1cobcsw::DeserializeFrom<endianness>(source, &(data->u16));
+    source = sts1cobcsw::DeserializeFrom<endianness>(source, &(data->i32));
+    source = sts1cobcsw::DeserializeFrom<endianness>(source, &(data->u8));
+    return source;
 }

--- a/Tests/UnitTests/FramRingArray.test.cpp
+++ b/Tests/UnitTests/FramRingArray.test.cpp
@@ -191,9 +191,6 @@ auto RunUnitTest() -> void
         Require(charRingArray.Get(1) == 22);
     }
 
-    // TODO: Add tests with custom types
-    // We need to provide serialization functions
-
     // SECTION("ProgramStatusHistoryEntry test")
     {
         using sts1cobcsw::serialSize;

--- a/Tests/UnitTests/FramRingArray.test.cpp
+++ b/Tests/UnitTests/FramRingArray.test.cpp
@@ -1,11 +1,15 @@
 #include <Tests/UnitTests/UnitTestThread.hpp>
 
+#include <Sts1CobcSw/Edu/ProgramStatusHistory.hpp>
 #include <Sts1CobcSw/FramSections/RingArray.hpp>
 #include <Sts1CobcSw/FramSections/Section.hpp>
 #include <Sts1CobcSw/Periphery/Fram.hpp>
 #include <Sts1CobcSw/Periphery/FramMock.hpp>
+#include <Sts1CobcSw/ProgramId/ProgramId.hpp>
 #include <Sts1CobcSw/Serial/Byte.hpp>
+#include <Sts1CobcSw/Serial/Serial.hpp>
 #include <Sts1CobcSw/Utility/ErrorDetectionAndCorrection.hpp>
+#include <Sts1CobcSw/Utility/TimeTypes.hpp>
 
 #include <strong_type/equality.hpp>
 #include <strong_type/type.hpp>
@@ -19,10 +23,48 @@
 namespace fram = sts1cobcsw::fram;
 using sts1cobcsw::operator""_b;  // NOLINT(misc-unused-using-decls)
 
+namespace sts1cobcsw::edu
+{
+using sts1cobcsw::DeserializeFrom;
+using sts1cobcsw::SerializeTo;
+
+
+template<std::endian endianness>
+auto DeserializeFrom(void const * source, ProgramStatusHistoryEntry * data) -> void const *
+{
+    source = DeserializeFrom<endianness>(source, &(data->programId));
+    source = DeserializeFrom<endianness>(source, &(data->startTime));
+    source = DeserializeFrom<endianness>(source, &(data->status));
+    return source;
+}
+
+
+template<std::endian endianness>
+auto SerializeTo(void * destination, ProgramStatusHistoryEntry const & data) -> void *
+{
+    destination = SerializeTo<endianness>(destination, data.programId);
+    destination = SerializeTo<endianness>(destination, data.startTime);
+    destination = SerializeTo<endianness>(destination, data.status);
+    return destination;
+}
+
+
+template auto DeserializeFrom<std::endian::big>(void const *, ProgramStatusHistoryEntry *)
+    -> void const *;
+template auto DeserializeFrom<std::endian::little>(void const *, ProgramStatusHistoryEntry *)
+    -> void const *;
+template auto SerializeTo<std::endian::big>(void *, ProgramStatusHistoryEntry const &) -> void *;
+template auto SerializeTo<std::endian::little>(void *, ProgramStatusHistoryEntry const &) -> void *;
+}
 
 inline constexpr auto section =
     sts1cobcsw::Section<fram::Address(0), fram::Size(3 * 2 * sizeof(std::size_t) + 4)>{};
+
+inline constexpr auto programStatusHistorySection = 
+    sts1cobcsw::Section<fram::Address(3*2*sizeof(std::size_t)+4), fram::Size(3 * 2 * sizeof(std::size_t)+ sts1cobcsw::serialSize<sts1cobcsw::edu::ProgramStatusHistoryEntry> * 4)>{};
+
 inline constexpr auto charRingArray = sts1cobcsw::RingArray<char, section, 2>{};
+inline constexpr auto programStatusHistory = sts1cobcsw::RingArray<sts1cobcsw::edu::ProgramStatusHistoryEntry, programStatusHistorySection, 2>{};
 
 static_assert(std::is_same_v<decltype(charRingArray)::ValueType, char>);
 static_assert(charRingArray.FramCapacity() == 3);
@@ -30,6 +72,12 @@ static_assert(charRingArray.CacheCapacity() == 2);
 static_assert(charRingArray.section.begin == fram::Address(0));
 static_assert(charRingArray.section.end == fram::Address(28));
 static_assert(charRingArray.section.size == fram::Size(28));
+
+static_assert(programStatusHistory.FramCapacity() == 3);
+static_assert(programStatusHistory.CacheCapacity() == 2);
+
+
+// TODO: Static asserts for custom type ring array
 
 
 auto RunUnitTest() -> void
@@ -39,6 +87,7 @@ auto RunUnitTest() -> void
     fram::ram::SetAllDoFunctions();
     fram::Initialize();
     static constexpr auto ringArrayStartAddress = 3 * 2 * sizeof(std::size_t);
+    static constexpr auto programStatusHistoryStartAddress = 3 * 2 * sizeof(std::size_t) + 4 + 3 * 2 * sizeof(std::size_t);
 
 
     // SECTION("FRAM is working")
@@ -164,4 +213,103 @@ auto RunUnitTest() -> void
     }
 
     // TODO: Add tests with custom types
+    // We need to provide serialization functions
+
+    // SECTION("ProgramStatusHistoryEntry test")
+    {
+        using sts1cobcsw::edu::ProgramStatusHistoryEntry;
+        memory.fill(0x00_b); 
+        fram::framIsWorking.Store(true);
+
+        Require(programStatusHistory.Size() == 0);
+
+        // Create a program status history entry
+
+        auto entry = ProgramStatusHistoryEntry{.programId = sts1cobcsw::ProgramId(1),
+                                                   .startTime = sts1cobcsw::RealTime(10),
+                                                   .status = sts1cobcsw::edu::ProgramStatus::programRunning};
+
+        auto entry2 = ProgramStatusHistoryEntry{.programId = sts1cobcsw::ProgramId(2),
+                                                   .startTime = sts1cobcsw::RealTime(10),
+                                                   .status = sts1cobcsw::edu::ProgramStatus::programRunning};
+
+        auto entry3 = ProgramStatusHistoryEntry{.programId = sts1cobcsw::ProgramId(3),
+                                                   .startTime = sts1cobcsw::RealTime(10),
+                                                   .status = sts1cobcsw::edu::ProgramStatus::programRunning};
+
+        auto entry4 = ProgramStatusHistoryEntry{.programId = sts1cobcsw::ProgramId(4),
+                                                .startTime = sts1cobcsw::RealTime(10),
+                                                .status = sts1cobcsw::edu::ProgramStatus::programRunning};
+
+        auto entry5 = ProgramStatusHistoryEntry{.programId = sts1cobcsw::ProgramId(5),
+                                                .startTime = sts1cobcsw::RealTime(10),
+                                                .status = sts1cobcsw::edu::ProgramStatus::programRunning};
+
+
+        Require(entry.programId == sts1cobcsw::ProgramId{1});
+
+        Require(programStatusHistory.Size() == 0);
+        
+
+         // Trying to set an element in an empty ring prints a debug message and does not set
+        // anything
+        programStatusHistory.Set(0, entry);
+        Require(std::all_of(memory.begin(), memory.end(), [](auto x) { return x == 0_b; }));
+
+        programStatusHistory.PushBack(entry);
+        Require(programStatusHistory.Size() == 1);
+        Require(programStatusHistory.Front().programId == sts1cobcsw::ProgramId(1));
+        Require(programStatusHistory.Back().programId == sts1cobcsw::ProgramId(1));
+
+        programStatusHistory.PushBack(entry2);
+        Require(programStatusHistory.Size() == 2);
+        //Require(programStatusHistory.Front() == 11);
+        //Require(programStatusHistory.Back() == 12);
+
+        programStatusHistory.PushBack(entry3);
+        Require(programStatusHistory.Size() == 3);
+        Require(programStatusHistory.Front().programId.value_of() == 1);
+        Require(programStatusHistory.Back().programId.value_of() == 3);
+
+        Require(programStatusHistory.Get(0).startTime.value_of() == 10);
+        Require(programStatusHistory.Get(1).startTime.value_of() == 10);
+        Require(programStatusHistory.Get(2).startTime.value_of() == 10);
+
+        // PushBack writes to memory
+        Require(fram::ram::memory[programStatusHistoryStartAddress + 0] == 1_b);
+        Require(fram::ram::memory[programStatusHistoryStartAddress + 2] == 10_b);
+
+        // When pushing to a full ring, the size stays the same and the oldest element is lost
+        programStatusHistory.PushBack(entry4);
+        Require(programStatusHistory.Size() == 3);
+        Require(programStatusHistory.Front().programId.value_of() == 2);
+        Require(programStatusHistory.Back().programId.value_of() == 4);
+
+        //// Only the (size + 2)th element overwrites the first one in memory because we keep a gap of
+        //// one between begin and end indexes
+        programStatusHistory.PushBack(entry5);
+        Require(programStatusHistory.Size() == 3);
+        Require(programStatusHistory.Front().programId.value_of() == 3);
+        Require(programStatusHistory.Back().programId.value_of() == 5);
+
+        // Set() writes to memory
+        //programStatusHistory.Set(0, 21);
+        //programStatusHistory.Set(1, 22);
+        //programStatusHistory.Set(2, 23);
+        //Require(programStatusHistory.Get(0) == 21);
+        //Require(programStatusHistory.Get(1) == 22);
+        //Require(programStatusHistory.Get(2) == 23);
+        //Require(fram::ram::memory[ringArrayStartAddress + 0] == 23_b);
+        //Require(fram::ram::memory[ringArrayStartAddress + 1] == 12_b);
+        //Require(fram::ram::memory[ringArrayStartAddress + 2] == 21_b);
+        //Require(fram::ram::memory[ringArrayStartAddress + 3] == 22_b);
+
+        // Get() with out-of-bounds index prints a debug message and returns the last element
+        Require(programStatusHistory.Get(17).programId.value_of() == 5);
+        //// Set() with out-of-bounds index prints a debug message and does not set anything
+        programStatusHistory.Set(17, entry); 
+        //Require(programStatusHistory.Get(0) == 21);
+        //Require(programStatusHistory.Get(1) == 22);
+        //Require(programStatusHistory.Get(2) == 23);
+    }
 }

--- a/Tests/UnitTests/FramRingArray.test.cpp
+++ b/Tests/UnitTests/FramRingArray.test.cpp
@@ -169,8 +169,8 @@ auto RunUnitTest() -> void
 
         // Even though we reset the FRAM memory to zero, the cached values are still there
         Require(charRingArray1.Size() == charRingArray1.CacheCapacity());
-        Require(charRingArray1.Get(0) == 21);
-        Require(charRingArray1.Get(1) == 22);
+        Require(charRingArray1.Get(0) == 22);
+        Require(charRingArray1.Get(1) == 23);
 
         Require(charRingArray2.Size() == 0);
         // Trying to set an element in an empty ring prints a debug message

--- a/Tests/UnitTests/FramRingArray.test.cpp
+++ b/Tests/UnitTests/FramRingArray.test.cpp
@@ -160,6 +160,17 @@ auto RunUnitTest() -> void
         Require(charRingArray1.Get(0) == 21);
         Require(charRingArray1.Get(1) == 22);
         Require(charRingArray1.Get(2) == 23);
+
+        charRingArray1.FindAndReplace([](auto x) { return x == 22; }, 42);
+        Require(charRingArray1.Get(0) == 21);
+        Require(charRingArray1.Get(1) == 42);
+        Require(charRingArray1.Get(2) == 23);
+        Require(fram::ram::memory[charRingArray1StartAddress + 3] == 42_b);
+
+        charRingArray1.FindAndReplace([](auto x) { return x == 0; }, 1);
+        Require(charRingArray1.Get(0) == 21);
+        Require(charRingArray1.Get(1) == 42);
+        Require(charRingArray1.Get(2) == 23);
     }
 
     // SECTION("FRAM is not working")
@@ -169,7 +180,7 @@ auto RunUnitTest() -> void
 
         // Even though we reset the FRAM memory to zero, the cached values are still there
         Require(charRingArray1.Size() == charRingArray1.CacheCapacity());
-        Require(charRingArray1.Get(0) == 22);
+        Require(charRingArray1.Get(0) == 42);
         Require(charRingArray1.Get(1) == 23);
 
         Require(charRingArray2.Size() == 0);
@@ -213,6 +224,14 @@ auto RunUnitTest() -> void
         charRingArray2.Set(17, 0);
         Require(charRingArray2.Get(0) == 21);
         Require(charRingArray2.Get(1) == 22);
+
+        charRingArray2.FindAndReplace([](auto x) { return x == 22; }, 42);
+        Require(charRingArray2.Get(0) == 21);
+        Require(charRingArray2.Get(1) == 42);
+
+        charRingArray2.FindAndReplace([](auto x) { return x == 0; }, 1);
+        Require(charRingArray2.Get(0) == 21);
+        Require(charRingArray2.Get(1) == 42);
     }
 
     // SECTION("RingArray of custom type")
@@ -291,6 +310,17 @@ auto RunUnitTest() -> void
         // Set() with out-of-bounds index prints a debug message and does not set anything
         sRingArray.Set(17, s1);
         Require(sRingArray.Get(0) == s6);
+        Require(sRingArray.Get(1) == s7);
+        Require(sRingArray.Get(2) == s8);
+
+        sRingArray.FindAndReplace([&s6](auto const & x) { return x == s6; }, s2);
+        Require(sRingArray.Get(0) == s2);
+        Require(sRingArray.Get(1) == s7);
+        Require(sRingArray.Get(2) == s8);
+        Require(fram::ram::memory[sRingArrayStartAddress + 2 * totalSerialSize<S>] == 2_b);
+
+        sRingArray.FindAndReplace([](auto const & x) { return x == S{}; }, s1);
+        Require(sRingArray.Get(0) == s2);
         Require(sRingArray.Get(1) == s7);
         Require(sRingArray.Get(2) == s8);
     }

--- a/Tests/UnitTests/FramRingArray.test.cpp
+++ b/Tests/UnitTests/FramRingArray.test.cpp
@@ -141,6 +141,8 @@ auto RunUnitTest() -> void
         // Set() writes to memory
         charRingArray.Set(0, 21);
         charRingArray.Set(1, 22);
+        // Set() with an out-of-bounds index for the cache prints a debug message and does not write
+        // to the cache
         charRingArray.Set(2, 23);
         Require(charRingArray.Get(0) == 21);
         Require(charRingArray.Get(1) == 22);


### PR DESCRIPTION
### Description

Move EDU program status history to FRAM by using the `fram::RingArray` to store program status history entries. Additionally, improve the unit test for `RingArray` with the addition of a custom type `RingArray` test case.

Fixes #204
