### PR TITLE
Update docker image, reduce binary sizes, and fix tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "STS1 COBC",
-    "image": "tuwienspaceteam/sts1-cobc:1.10.0",
+    "image": "tuwienspaceteam/sts1-cobc:1.12.0",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   format-and-spell-check:
     runs-on: ubuntu-latest
-    container: tuwienspaceteam/sts1-cobc:1.10.0-linux-x86
+    container: tuwienspaceteam/sts1-cobc:1.12.0-linux-x86
 
     steps:
     - uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
     needs: format-and-spell-check
 
     runs-on: ubuntu-latest
-    container: tuwienspaceteam/sts1-cobc:1.10.0-linux-x86
+    container: tuwienspaceteam/sts1-cobc:1.12.0-linux-x86
 
     steps:
     - uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
     needs: format-and-spell-check
 
     runs-on: ubuntu-latest
-    container: tuwienspaceteam/sts1-cobc:1.10.0-linux-x86
+    container: tuwienspaceteam/sts1-cobc:1.12.0-linux-x86
 
     steps:
     - uses: actions/checkout@v4
@@ -97,7 +97,7 @@ jobs:
     needs: format-and-spell-check
 
     runs-on: ubuntu-latest
-    container: tuwienspaceteam/sts1-cobc:1.10.0
+    container: tuwienspaceteam/sts1-cobc:1.12.0
 
     steps:
     - uses: actions/checkout@v4
@@ -147,7 +147,7 @@ jobs:
     needs: format-and-spell-check
 
     runs-on: ubuntu-latest
-    container: tuwienspaceteam/sts1-cobc:1.10.0-linux-x86
+    container: tuwienspaceteam/sts1-cobc:1.12.0-linux-x86
 
     steps:
     - uses: actions/checkout@v4

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -93,7 +93,7 @@
         "cpp-std"
       ],
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_BUILD_TYPE": "MinSizeRel",
         "USE_CCACHE": "OFF"
       }
     },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -40,7 +40,7 @@
       "name": "clang-tidy",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_CXX_CLANG_TIDY": "clang-tidy;--header-filter=${sourceDir}/*"
+        "CMAKE_CXX_CLANG_TIDY": "clang-tidy;--header-filter=${sourceDir}/*;--extra-arg=-fsized-deallocation"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -81,9 +81,7 @@
       "hidden": true,
       "inherits": "warnings-unix",
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "$env{WARNINGS}",
-        "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g -DDEBUG",
-        "CMAKE_CXX_FLAGS_RELEASE": "-Os"
+        "CMAKE_CXX_FLAGS": "$env{WARNINGS}"
       }
     },
     {

--- a/Sts1CobcSw/CobcSoftware/CommandParser.cpp
+++ b/Sts1CobcSw/CobcSoftware/CommandParser.cpp
@@ -5,8 +5,6 @@
 #include <Sts1CobcSw/Serial/Serial.hpp>
 #include <Sts1CobcSw/Utility/DebugPrint.hpp>
 
-#include <strong_type/type.hpp>
-
 #include <cinttypes>  // IWYU pragma: keep
 
 

--- a/Sts1CobcSw/CobcSoftware/CommandParser.cpp
+++ b/Sts1CobcSw/CobcSoftware/CommandParser.cpp
@@ -3,7 +3,7 @@
 #include <Sts1CobcSw/Edu/Edu.hpp>
 #include <Sts1CobcSw/Edu/ProgramQueue.hpp>
 #include <Sts1CobcSw/Serial/Serial.hpp>
-#include <Sts1CobcSw/Utility/Debug.hpp>
+#include <Sts1CobcSw/Utility/DebugPrint.hpp>
 
 #include <strong_type/type.hpp>
 

--- a/Sts1CobcSw/CobcSoftware/EduCommunicationErrorThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/EduCommunicationErrorThread.cpp
@@ -4,7 +4,7 @@
 #include <Sts1CobcSw/Edu/Edu.hpp>
 #include <Sts1CobcSw/FramSections/FramLayout.hpp>
 #include <Sts1CobcSw/FramSections/PersistentVariables.hpp>
-#include <Sts1CobcSw/Utility/Debug.hpp>
+#include <Sts1CobcSw/Utility/DebugPrint.hpp>
 #include <Sts1CobcSw/Utility/RodosTime.hpp>
 
 #include <strong_type/difference.hpp>

--- a/Sts1CobcSw/CobcSoftware/EduHeartbeatThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/EduHeartbeatThread.cpp
@@ -2,7 +2,7 @@
 #include <Sts1CobcSw/CobcSoftware/TopicsAndSubscribers.hpp>
 #include <Sts1CobcSw/Hal/GpioPin.hpp>
 #include <Sts1CobcSw/Hal/IoNames.hpp>
-#include <Sts1CobcSw/Utility/Debug.hpp>
+#include <Sts1CobcSw/Utility/DebugPrint.hpp>
 #include <Sts1CobcSw/Utility/RodosTime.hpp>
 #include <Sts1CobcSw/Utility/TimeTypes.hpp>
 

--- a/Sts1CobcSw/CobcSoftware/EduPowerManagementThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/EduPowerManagementThread.cpp
@@ -4,7 +4,7 @@
 #include <Sts1CobcSw/Edu/Edu.hpp>
 #include <Sts1CobcSw/Hal/GpioPin.hpp>
 #include <Sts1CobcSw/Hal/IoNames.hpp>
-#include <Sts1CobcSw/Utility/Debug.hpp>
+#include <Sts1CobcSw/Utility/DebugPrint.hpp>
 #include <Sts1CobcSw/Utility/RodosTime.hpp>
 #include <Sts1CobcSw/Utility/TimeTypes.hpp>
 

--- a/Sts1CobcSw/CobcSoftware/EduProgramQueueThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/EduProgramQueueThread.cpp
@@ -8,7 +8,7 @@
 #include <Sts1CobcSw/Edu/Types.hpp>
 #include <Sts1CobcSw/FramSections/RingArray.hpp>
 #include <Sts1CobcSw/ProgramId/ProgramId.hpp>  // IWYU pragma: keep
-#include <Sts1CobcSw/Utility/Debug.hpp>
+#include <Sts1CobcSw/Utility/DebugPrint.hpp>
 #include <Sts1CobcSw/Utility/RealTime.hpp>
 #include <Sts1CobcSw/Utility/RodosTime.hpp>
 #include <Sts1CobcSw/Utility/TimeTypes.hpp>

--- a/Sts1CobcSw/CobcSoftware/FlashStartupTestThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/FlashStartupTestThread.cpp
@@ -12,7 +12,8 @@
 
 namespace sts1cobcsw
 {
-constexpr auto stackSize = 100U;
+// Running the SpiSupervisor HW test showed that the minimum required stack size is ~560 bytes
+constexpr auto stackSize = 600;
 
 
 class FlashStartupTestThread : public RODOS::StaticThread<stackSize>

--- a/Sts1CobcSw/CobcSoftware/FlashStartupTestThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/FlashStartupTestThread.cpp
@@ -4,7 +4,7 @@
 #include <Sts1CobcSw/FramSections/FramLayout.hpp>
 #include <Sts1CobcSw/FramSections/PersistentVariables.hpp>
 #include <Sts1CobcSw/Periphery/Flash.hpp>
-#include <Sts1CobcSw/Utility/Debug.hpp>
+#include <Sts1CobcSw/Utility/DebugPrint.hpp>
 #include <Sts1CobcSw/Utility/RodosTime.hpp>
 
 #include <rodos_no_using_namespace.h>

--- a/Sts1CobcSw/CobcSoftware/FramEpsStartupTestThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/FramEpsStartupTestThread.cpp
@@ -5,7 +5,7 @@
 #include <Sts1CobcSw/FramSections/PersistentVariables.hpp>
 #include <Sts1CobcSw/Periphery/Eps.hpp>
 #include <Sts1CobcSw/Periphery/Fram.hpp>
-#include <Sts1CobcSw/Utility/Debug.hpp>
+#include <Sts1CobcSw/Utility/DebugPrint.hpp>
 #include <Sts1CobcSw/Utility/ErrorDetectionAndCorrection.hpp>
 #include <Sts1CobcSw/Utility/RodosTime.hpp>
 

--- a/Sts1CobcSw/CobcSoftware/FramEpsStartupTestThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/FramEpsStartupTestThread.cpp
@@ -17,7 +17,8 @@
 
 namespace sts1cobcsw
 {
-constexpr auto stackSize = 100U;
+// Running the SpiSupervisor HW test showed that the minimum required stack size is ~800 bytes
+constexpr auto stackSize = 850;
 
 
 class FramEpsStartupTestThread : public RODOS::StaticThread<stackSize>

--- a/Sts1CobcSw/CobcSoftware/RfStartupTestThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/RfStartupTestThread.cpp
@@ -4,7 +4,7 @@
 #include <Sts1CobcSw/FramSections/FramLayout.hpp>
 #include <Sts1CobcSw/FramSections/PersistentVariables.hpp>
 #include <Sts1CobcSw/Periphery/Rf.hpp>
-#include <Sts1CobcSw/Utility/Debug.hpp>
+#include <Sts1CobcSw/Utility/DebugPrint.hpp>
 #include <Sts1CobcSw/Utility/RodosTime.hpp>
 
 #include <rodos_no_using_namespace.h>

--- a/Sts1CobcSw/CobcSoftware/RfStartupTestThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/RfStartupTestThread.cpp
@@ -12,7 +12,8 @@
 
 namespace sts1cobcsw
 {
-constexpr auto stackSize = 100U;
+// Running the SpiSupervisor HW test showed that the minimum required stack size is ~765 bytes
+constexpr auto stackSize = 800;
 
 
 class RfStartupTestThread : public RODOS::StaticThread<stackSize>

--- a/Sts1CobcSw/CobcSoftware/SpiStartupTestAndSupervisorThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/SpiStartupTestAndSupervisorThread.cpp
@@ -10,8 +10,6 @@
 #include <Sts1CobcSw/Periphery/Spis.hpp>
 #include <Sts1CobcSw/Utility/DebugPrint.hpp>
 #include <Sts1CobcSw/Utility/ErrorDetectionAndCorrection.hpp>
-#include <Sts1CobcSw/Utility/RodosTime.hpp>
-#include <Sts1CobcSw/Utility/TimeTypes.hpp>
 
 #include <strong_type/affine_point.hpp>
 #include <strong_type/difference.hpp>
@@ -25,11 +23,10 @@
 
 namespace sts1cobcsw
 {
-// Running the integration test for the supervisor thread showed that at least 850 bytes are needed
-constexpr auto stackSize = 900U + EXTRA_SANITIZER_STACK_SIZE;
-constexpr auto initialSleepTime = 10 * ms;
-// TODO: Measure how long the startup tests really take to determine the correct timeout
-constexpr auto startupTestTimeout = 100 * ms;
+// Running the golden test for the supervisor thread showed that at least 850 bytes are needed
+constexpr auto stackSize = 900 + EXTRA_SANITIZER_STACK_SIZE;
+
+inline constexpr auto initialSleepTime = 10 * ms;
 // TODO: Think about how often the supervision should run
 constexpr auto supervisionPeriod = 1 * s;
 
@@ -95,6 +92,8 @@ private:
             DEBUG_PRINT("%s", errorMessage);
             persistentVariables.template Store<"rfIsWorking">(false);
             persistentVariables.template Increment<"nRfErrors">();
+            DEBUG_PRINT("Resetting and rebooting in 2 s\n");
+            // TODO: Add a named constant for this delay
             SuspendFor(2 * s);
             RODOS::hwResetAndReboot();
         }

--- a/Sts1CobcSw/CobcSoftware/SpiStartupTestAndSupervisorThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/SpiStartupTestAndSupervisorThread.cpp
@@ -10,6 +10,7 @@
 #include <Sts1CobcSw/Periphery/Spis.hpp>
 #include <Sts1CobcSw/Utility/DebugPrint.hpp>
 #include <Sts1CobcSw/Utility/ErrorDetectionAndCorrection.hpp>
+#include <Sts1CobcSw/Utility/TimeTypes.hpp>
 
 #include <strong_type/affine_point.hpp>
 #include <strong_type/difference.hpp>

--- a/Sts1CobcSw/CobcSoftware/SpiStartupTestAndSupervisorThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/SpiStartupTestAndSupervisorThread.cpp
@@ -8,7 +8,7 @@
 #include <Sts1CobcSw/Hal/Spi.hpp>
 #include <Sts1CobcSw/Periphery/Fram.hpp>
 #include <Sts1CobcSw/Periphery/Spis.hpp>
-#include <Sts1CobcSw/Utility/Debug.hpp>
+#include <Sts1CobcSw/Utility/DebugPrint.hpp>
 #include <Sts1CobcSw/Utility/ErrorDetectionAndCorrection.hpp>
 #include <Sts1CobcSw/Utility/RodosTime.hpp>
 #include <Sts1CobcSw/Utility/TimeTypes.hpp>

--- a/Sts1CobcSw/CobcSoftware/SpiStartupTestAndSupervisorThread.hpp
+++ b/Sts1CobcSw/CobcSoftware/SpiStartupTestAndSupervisorThread.hpp
@@ -2,7 +2,8 @@
 
 
 #include <Sts1CobcSw/Utility/RodosTime.hpp>
-#include <Sts1CobcSw/Utility/TimeTypes.hpp>
+
+#include <strong_type/difference.hpp>
 
 
 namespace sts1cobcsw

--- a/Sts1CobcSw/CobcSoftware/SpiStartupTestAndSupervisorThread.hpp
+++ b/Sts1CobcSw/CobcSoftware/SpiStartupTestAndSupervisorThread.hpp
@@ -1,7 +1,14 @@
 #pragma once
 
 
+#include <Sts1CobcSw/Utility/RodosTime.hpp>
+#include <Sts1CobcSw/Utility/TimeTypes.hpp>
+
+
 namespace sts1cobcsw
 {
+// TODO: Measure how long the startup tests really take to determine the correct timeouts
+inline constexpr auto startupTestTimeout = 100 * ms;
+inline constexpr auto totalStartupTestTimeout = 3 * startupTestTimeout + 50 * ms;
 auto ResumeSpiStartupTestAndSupervisorThread() -> void;
 }

--- a/Sts1CobcSw/CobcSoftware/StartupTestThreadStubs.cpp
+++ b/Sts1CobcSw/CobcSoftware/StartupTestThreadStubs.cpp
@@ -3,7 +3,7 @@
 #include <Sts1CobcSw/FramSections/FramLayout.hpp>
 #include <Sts1CobcSw/FramSections/PersistentVariables.hpp>
 #include <Sts1CobcSw/Periphery/Fram.hpp>
-#include <Sts1CobcSw/Utility/Debug.hpp>
+#include <Sts1CobcSw/Utility/DebugPrint.hpp>
 #include <Sts1CobcSw/Utility/ErrorDetectionAndCorrection.hpp>
 #include <Sts1CobcSw/Utility/RodosTime.hpp>
 

--- a/Sts1CobcSw/Edu/Edu.cpp
+++ b/Sts1CobcSw/Edu/Edu.cpp
@@ -9,7 +9,7 @@
 #include <Sts1CobcSw/Serial/Byte.hpp>
 #include <Sts1CobcSw/Serial/Serial.hpp>
 #include <Sts1CobcSw/Utility/Crc32Software.hpp>
-#include <Sts1CobcSw/Utility/Debug.hpp>
+#include <Sts1CobcSw/Utility/DebugPrint.hpp>
 #include <Sts1CobcSw/Utility/RodosTime.hpp>
 #include <Sts1CobcSw/Utility/Span.hpp>
 

--- a/Sts1CobcSw/Edu/EduMock.cpp
+++ b/Sts1CobcSw/Edu/EduMock.cpp
@@ -2,8 +2,6 @@
 #include <Sts1CobcSw/Edu/Types.hpp>
 #include <Sts1CobcSw/Utility/DebugPrint.hpp>
 
-#include <strong_type/type.hpp>
-
 #include <cinttypes>  // IWYU pragma: keep
 
 

--- a/Sts1CobcSw/Edu/EduMock.cpp
+++ b/Sts1CobcSw/Edu/EduMock.cpp
@@ -1,6 +1,6 @@
 #include <Sts1CobcSw/Edu/Edu.hpp>  // IWYU pragma: associated
 #include <Sts1CobcSw/Edu/Types.hpp>
-#include <Sts1CobcSw/Utility/Debug.hpp>
+#include <Sts1CobcSw/Utility/DebugPrint.hpp>
 
 #include <strong_type/type.hpp>
 

--- a/Sts1CobcSw/FramSections/RingArray.ipp
+++ b/Sts1CobcSw/FramSections/RingArray.ipp
@@ -2,7 +2,7 @@
 
 
 #include <Sts1CobcSw/FramSections/RingArray.hpp>
-#include <Sts1CobcSw/Utility/Debug.hpp>
+#include <Sts1CobcSw/Utility/DebugPrint.hpp>
 #include <Sts1CobcSw/Utility/Span.hpp>
 
 

--- a/Sts1CobcSw/HelloDummy.cpp
+++ b/Sts1CobcSw/HelloDummy.cpp
@@ -1,5 +1,5 @@
 #include <Sts1CobcSw/Dummy.hpp>
-#include <Sts1CobcSw/Utility/Debug.hpp>
+#include <Sts1CobcSw/Utility/DebugPrint.hpp>
 
 #include <rodos_no_using_namespace.h>
 

--- a/Sts1CobcSw/Utility/CMakeLists.txt
+++ b/Sts1CobcSw/Utility/CMakeLists.txt
@@ -3,6 +3,9 @@ target_link_libraries(
     Sts1CobcSw_Utility PUBLIC etl::etl rodos::without_main_on_linux strong_type::strong_type
                               Sts1CobcSw_Serial
 )
+target_compile_definitions(
+    Sts1CobcSw_Utility PUBLIC $<$<CONFIG:Debug,RelWithDebInfo>:ENABLE_DEBUG_PRINT>
+)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Generic)
     target_sources(Sts1CobcSw_Utility PRIVATE Crc32Hardware.cpp)

--- a/Sts1CobcSw/Utility/DebugPrint.hpp
+++ b/Sts1CobcSw/Utility/DebugPrint.hpp
@@ -8,7 +8,7 @@
 #include <cinttypes>
 
 
-#ifdef DEBUG
+#ifdef ENABLE_DEBUG_PRINT
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wpedantic"
     // NOLINTNEXTLINE(cppcoreguidelines-macro-usage, *variadic-macro-arguments)

--- a/Tests/GoldenTests/SpiSupervisor.test.cpp
+++ b/Tests/GoldenTests/SpiSupervisor.test.cpp
@@ -1,3 +1,4 @@
+#include <Sts1CobcSw/CobcSoftware/SpiStartupTestAndSupervisorThread.hpp>
 #include <Sts1CobcSw/Hal/Spi.hpp>
 #include <Sts1CobcSw/Hal/SpiMock.hpp>
 #include <Sts1CobcSw/Periphery/Fram.hpp>
@@ -61,7 +62,7 @@ public:
 
     void run() override
     {
-        SuspendFor(100 * ms);
+        SuspendFor(totalStartupTestTimeout);
 
         PRINTF("\nSPI supervisor test\n\n");
 

--- a/Tests/HardwareTests/Littlefs.test.cpp
+++ b/Tests/HardwareTests/Littlefs.test.cpp
@@ -39,8 +39,7 @@ private:
     {
         EnableRfLatchupProtection();
 
-        PRINTF("\n\n");
-        PRINTF("littlefs test\n");
+        PRINTF("\n\nlittlefs test\n");
 
         PRINTF("\n");
         auto lfs = lfs_t{};
@@ -56,7 +55,6 @@ private:
         PRINTF("Creating directory '%s' ...\n", directoryPath);
         errorCode = lfs_mkdir(&lfs, directoryPath);
         Check(errorCode == 0);
-
         PRINTF("\n");
         auto const * filePath = "MyFolder/MyFile";
         PRINTF("Creating file '%s' ...\n", filePath);
@@ -92,6 +90,33 @@ private:
         PRINTF("Closing file ...\n");
         errorCode = lfs_file_close(&lfs, &file);
         Check(errorCode == 0);
+
+        PRINTF("\n");
+        PRINTF("Removing the non-empty directory '%s' should fail ...\n", directoryPath);
+        errorCode = lfs_remove(&lfs, directoryPath);
+        PRINTF("Error code = %d == %d\n", errorCode, LFS_ERR_NOTEMPTY);
+        Check(errorCode == LFS_ERR_NOTEMPTY);
+        PRINTF("Removing the file '%s' ...\n", filePath);
+        errorCode = lfs_remove(&lfs, filePath);
+        Check(errorCode == 0);
+        PRINTF("Removing the empty directory '%s' ...\n", directoryPath);
+        errorCode = lfs_remove(&lfs, directoryPath);
+        Check(errorCode == 0);
+
+        PRINTF("\n");
+        PRINTF("Unmounting ...\n");
+        errorCode = lfs_unmount(&lfs);
+        Check(errorCode == 0);
+
+        PRINTF("\n");
+        if(AllChecksPassed())
+        {
+            PRINTF("ALL CHECKS PASSED :)\n");
+        }
+        else
+        {
+            PRINTF("SOME CHECKS FAILED :(\n");
+        }
     }
 } littlefsTest;
 }

--- a/Tests/HardwareTests/SpiSupervisor.test.cpp
+++ b/Tests/HardwareTests/SpiSupervisor.test.cpp
@@ -1,5 +1,6 @@
 #include <Tests/HardwareTests/RfLatchupDisablePin.hpp>
 
+#include <Sts1CobcSw/CobcSoftware/SpiStartupTestAndSupervisorThread.hpp>
 #include <Sts1CobcSw/Periphery/Flash.hpp>
 #include <Sts1CobcSw/Periphery/Fram.hpp>
 #include <Sts1CobcSw/Serial/Byte.hpp>
@@ -17,10 +18,11 @@
 
 namespace sts1cobcsw
 {
-using RODOS::PRINTF;
+// Running this test showed that the minimum required stack size is between 12.0 and 12.1 kB
+constexpr auto stackSize = 13'000;
 
 
-class SpiSupervisorTest : public RODOS::StaticThread<>
+class SpiSupervisorTest : public RODOS::StaticThread<stackSize>
 {
 public:
     SpiSupervisorTest() : StaticThread("SpiSupervisorTest")
@@ -37,7 +39,10 @@ private:
 
     void run() override
     {
+        using RODOS::PRINTF;
+
         EnableRfLatchupProtection();
+        SuspendFor(totalStartupTestTimeout);
 
         PRINTF("\nSPI supervisor test\n\n");
 
@@ -47,8 +52,12 @@ private:
         auto page = flash::ReadPage(flashAddress);
         PRINTF("Writing flash page ...\n");
         flash::ProgramPage(flashAddress, Span(page));
+        PRINTF("  done\n");
 
-        SuspendFor(2 * s);
+        PRINTF("\n");
+        PRINTF("Suspending for 1 s ...\n");
+        SuspendFor(1 * s);
+        PRINTF("  done\n");
 
         PRINTF("\n");
         RODOS::setRandSeed(static_cast<std::uint64_t>(RODOS::NOW()));
@@ -58,8 +67,11 @@ private:
         auto framTestData = std::array<Byte, 11 * 1024>{};
         // Baud rate = 6 MHz, data size = 11 KiB -> transfer time ~ 15 ms
         constexpr auto spiTimeout = 30 * ms;
-        PRINTF("Writing %d B to FRAM ...\n", static_cast<int>(framTestData.size()));
+        PRINTF("Writing %d B to FRAM at address 0x%05x ...\n",
+               static_cast<int>(framTestData.size()),
+               static_cast<unsigned>(value_of(framAddress)));
         fram::WriteTo(framAddress, Span(framTestData), spiTimeout);
+        PRINTF("  done\n\n");
     }
 
 } spiSupervisorTest;

--- a/Tests/HardwareTests/SpiSupervisor.test.cpp
+++ b/Tests/HardwareTests/SpiSupervisor.test.cpp
@@ -8,6 +8,7 @@
 #include <Sts1CobcSw/Utility/Span.hpp>
 
 #include <strong_type/difference.hpp>
+#include <strong_type/type.hpp>
 
 #include <rodos/support/support-libs/random.h>
 #include <rodos_no_using_namespace.h>

--- a/Tests/HardwareTests/Utility.cpp
+++ b/Tests/HardwareTests/Utility.cpp
@@ -5,6 +5,9 @@
 
 namespace sts1cobcsw
 {
+auto allChecksPassed = true;
+
+
 auto Check(bool condition, std::string_view failMessage, std::string_view successMessage) -> void
 {
     if(condition)
@@ -13,7 +16,14 @@ auto Check(bool condition, std::string_view failMessage, std::string_view succes
     }
     else
     {
+        allChecksPassed = false;
         RODOS::PRINTF("%s", failMessage.data());
     }
+}
+
+
+auto AllChecksPassed() -> bool
+{
+    return allChecksPassed;
 }
 }

--- a/Tests/HardwareTests/Utility.hpp
+++ b/Tests/HardwareTests/Utility.hpp
@@ -9,4 +9,5 @@ namespace sts1cobcsw
 auto Check(bool condition,
            std::string_view failMessage = " -> Failed\n",
            std::string_view successMessage = " -> Passed\n") -> void;
+auto AllChecksPassed() -> bool;
 }

--- a/Tests/UnitTests/EdacVariable.test.cpp
+++ b/Tests/UnitTests/EdacVariable.test.cpp
@@ -2,6 +2,7 @@
 
 #include <Sts1CobcSw/Utility/ErrorDetectionAndCorrection.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstring>

--- a/Tests/UnitTests/EdacVariable.test.cpp
+++ b/Tests/UnitTests/EdacVariable.test.cpp
@@ -3,6 +3,7 @@
 #include <Sts1CobcSw/Utility/ErrorDetectionAndCorrection.hpp>
 
 #include <array>
+#include <cmath>
 #include <cstring>
 #include <type_traits>
 
@@ -18,6 +19,12 @@ struct S
 };
 
 
+auto ApproximatelyEqual(double lhs, double rhs, double relativeTolerance = 1e-6) -> bool
+{
+    return std::abs(lhs - rhs) < relativeTolerance * std::max(std::abs(lhs), std::abs(rhs));
+}
+
+
 auto RunUnitTest() -> void
 {
     using sts1cobcsw::EdacVariable;
@@ -29,7 +36,7 @@ auto RunUnitTest() -> void
         auto variable3 = EdacVariable<double>(-3.14);
         Require(variable1.Load().c == 's');
         Require(variable2.Load() == 0);
-        Require(variable3.Load() == -3.14);
+        Require(ApproximatelyEqual(variable3.Load(), -3.14));
     }
 
     // SECTION("You load what you store")

--- a/cmake/custom-commands.cmake
+++ b/cmake/custom-commands.cmake
@@ -23,33 +23,34 @@ function(find_rodos)
 endfunction()
 
 function(add_program program_name)
-    add_executable(${PROJECT_NAME}_${program_name} ${ARGN})
-    set_target_properties(${PROJECT_NAME}_${program_name} PROPERTIES OUTPUT_NAME ${program_name})
+    set(target ${PROJECT_NAME}_${program_name})
+    add_executable(${target} ${ARGN})
+    set_target_properties(${target} PROPERTIES OUTPUT_NAME ${program_name})
 
     # Add a definition of the target system
     if(CMAKE_SYSTEM_NAME STREQUAL Generic)
-        target_compile_definitions(${PROJECT_NAME}_${program_name} PUBLIC GENERIC_SYSTEM)
-        message("Adding -DGENERIC_SYSTEM to ${PROJECT_NAME}_${program_name}")
+        target_compile_definitions(${target} PUBLIC GENERIC_SYSTEM)
+        message("Adding -DGENERIC_SYSTEM to ${target}")
     elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
-        target_compile_definitions(${PROJECT_NAME}_${program_name} PUBLIC LINUX_SYSTEM)
-        message("Adding -DLINUX_SYSTEM to ${PROJECT_NAME}_${program_name}")
+        target_compile_definitions(${target} PUBLIC LINUX_SYSTEM)
+        message("Adding -DLINUX_SYSTEM to ${target}")
     else()
         message(SEND_ERROR "CMAKE_SYSTEM_NAME is neither Generic nor Linux")
     endif()
 
     if(CMAKE_SYSTEM_NAME STREQUAL Generic)
         # Automatically call objcopy on the executable targets after the build
-        objcopy_target(${PROJECT_NAME}_${program_name})
+        objcopy_target(${target})
     endif()
 endfunction()
 
-function(objcopy_target target_name)
-    get_target_property(output_name ${target_name} OUTPUT_NAME)
+function(objcopy_target target)
+    get_target_property(output_name ${target} OUTPUT_NAME)
     add_custom_command(
-        TARGET ${target_name}
+        TARGET ${target}
         POST_BUILD
-        COMMAND "${CMAKE_OBJCOPY}" -O binary ${output_name} ${output_name}.bin
-        BYPRODUCTS ${output_name}.bin
+        COMMAND "${CMAKE_OBJCOPY}" -O binary "$<TARGET_FILE:${target}>"
+                "$<TARGET_FILE:${target}>.bin"
         COMMENT "Calling objcopy on ${output_name} to generate flashable ${output_name}.bin"
         VERBATIM
     )

--- a/iwyu.imp
+++ b/iwyu.imp
@@ -119,4 +119,6 @@
   # Fixing iwyu bug where <tuple> is required to be include for array symbol
   # unfortunately, the `symbol` directive does not work
   { include: ["<tuple>", "public", "<array>", "public"] },
+
+  { include: ["<bits/std_abs.h>", "public", "<cmath>", "public"] },
 ]

--- a/iwyu.imp
+++ b/iwyu.imp
@@ -100,7 +100,7 @@
   { include: ["\"Sts1CobcSw/Serial/Serial.hpp\"",                       "public", "<Sts1CobcSw/Serial/Serial.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Utility/Crc32Hardware.hpp\"",               "public", "<Sts1CobcSw/Utility/Crc32Hardware.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Utility/Crc32Software.hpp\"",               "public", "<Sts1CobcSw/Utility/Crc32Software.hpp>", "public"] },
-  { include: ["\"Sts1CobcSw/Utility/Debug.hpp\"",                       "public", "<Sts1CobcSw/Utility/Debug.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Utility/DebugPrint.hpp\"",                  "public", "<Sts1CobcSw/Utility/DebugPrint.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Utility/ErrorDetectionAndCorrection.hpp\"", "public", "<Sts1CobcSw/Utility/ErrorDetectionAndCorrection.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Utility/FlatArray.hpp\"",                   "public", "<Sts1CobcSw/Utility/FlatArray.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Utility/RealTime.hpp\"",                    "public", "<Sts1CobcSw/Utility/RealTime.hpp>", "public"] },


### PR DESCRIPTION
The new Docker image is what allows us to significantly reduce the binary sizes and use the right flags for the four typical configurations by default. There were also some tests that no longer compiled, ran, or were otherwise not correct. I fixed those.

Fixes #332