### PR TITLE
Add integrity checks to file system 

### DIFF
--- a/Sts1CobcSw/FileSystem/LfsFlash.cpp
+++ b/Sts1CobcSw/FileSystem/LfsFlash.cpp
@@ -8,10 +8,13 @@
 
 #include <strong_type/difference.hpp>
 
+#include <littlefs/lfs_util.h>
+
 #include <rodos_no_using_namespace.h>
 
 #include <algorithm>
 #include <array>
+#include <cstring>
 #include <span>
 
 
@@ -39,6 +42,9 @@ constexpr auto pageProgramTimeout = 5 * ms;
 // max. 400 ms acc. W25Q01JV datasheet (lfs_config.block_size = flash::sectorSize)
 constexpr auto blockEraseTimeout = 500 * ms;
 
+constexpr auto pageSizeLfs = flash::pageSize - crcSize;
+constexpr auto sectorSizeLfs = flash::sectorSize - (flash::sectorSize / flash::pageSize * crcSize);
+
 auto readBuffer = std::array<Byte, lfsCacheSize>{};
 auto programBuffer = decltype(readBuffer){};
 auto lookaheadBuffer = std::array<Byte, 64>{};  // NOLINT(*magic-numbers)
@@ -46,7 +52,7 @@ auto lookaheadBuffer = std::array<Byte, 64>{};  // NOLINT(*magic-numbers)
 // littlefs requires the lookaheadBuffer size to be a multiple of 8
 static_assert(lookaheadBuffer.size() % 8 == 0);  // NOLINT(*magic-numbers)
 // littlefs requires the cacheSize to be a multiple of the read_size and prog_size, i.e., pageSize
-static_assert(lfsCacheSize % flash::pageSize == 0);
+static_assert(lfsCacheSize % pageSizeLfs == 0);
 
 lfs_config const lfsConfig = lfs_config{.context = nullptr,
                                         .read = &Read,
@@ -55,9 +61,9 @@ lfs_config const lfsConfig = lfs_config{.context = nullptr,
                                         .sync = &Sync,
                                         .lock = &Lock,
                                         .unlock = &Unlock,
-                                        .read_size = flash::pageSize,
-                                        .prog_size = flash::pageSize,
-                                        .block_size = flash::sectorSize,
+                                        .read_size = pageSizeLfs,
+                                        .prog_size = pageSizeLfs,
+                                        .block_size = sectorSizeLfs,
                                         .block_count = flash::nSectors,
                                         .block_cycles = 200,
                                         .cache_size = readBuffer.size(),
@@ -69,7 +75,7 @@ lfs_config const lfsConfig = lfs_config{.context = nullptr,
                                         .name_max = maxPathLength,
                                         .file_max = LFS_FILE_MAX,
                                         .attr_max = LFS_ATTR_MAX,
-                                        .metadata_max = flash::sectorSize,
+                                        .metadata_max = sectorSizeLfs,
                                         .inline_max = 0};
 
 auto semaphore = RODOS::Semaphore();
@@ -82,37 +88,68 @@ auto Initialize() -> void
 
 
 auto Read(lfs_config const * config,
-          lfs_block_t blockNo,
+          lfs_block_t blockNo,  // NOLINT(bugprone-easily-swappable-parameters)
           lfs_off_t offset,
           void * buffer,
           lfs_size_t size) -> int
 {
     // The following only works if read_size == pageSize
-    auto startAddress = blockNo * config->block_size + offset;
     for(auto i = 0U; i < size; i += config->read_size)
     {
-        auto page = flash::ReadPage(startAddress + i);
-        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-        std::copy(page.begin(), page.end(), (static_cast<Byte *>(buffer) + i));
+        auto const pages = (i + offset) / config->read_size;
+        auto const offsetCrc = pages * flash::pageSize;
+        auto const startAddress =
+            static_cast<std::uint32_t>(blockNo * flash::sectorSize + offsetCrc);
+
+        auto const page = flash::ReadPage(startAddress);
+
+        // if the page is filled with eraseValue -> page was just erased and the crc is not set
+        if(!std::all_of(page.begin(), page.end(), [](Byte byte) { return byte == eraseValue; }))
+        {
+            std::uint32_t crc = {};
+            std::memcpy(&crc, page.begin() + config->read_size, sizeof(crc));
+
+            const std::uint32_t crcCalculated =
+                lfs_crc(initialCrcValue, page.begin(), config->read_size);
+            if(crc != crcCalculated)
+            {
+                return LFS_ERR_CORRUPT;
+            }
+        }
+
+        std::copy_n(page.begin(),
+                    config->read_size,
+                    static_cast<Byte *>(buffer) + i);  // NOLINT(*pointer-arithmetic)
     }
     return 0;
 }
 
 auto Program(lfs_config const * config,
-             lfs_block_t blockNo,
+             lfs_block_t blockNo,  // NOLINT(bugprone-easily-swappable-parameters)
              lfs_off_t offset,
              void const * buffer,
              lfs_size_t size) -> int
 {
     // The following only works if prog_size == pageSize
-    auto startAddress = blockNo * config->block_size + offset;
     for(auto i = 0U; i < size; i += config->prog_size)
     {
+        auto const pages = (i + offset) / config->prog_size;
+        auto const offsetCrc = pages * flash::pageSize;
+        auto const startAddress =
+            static_cast<std::uint32_t>(blockNo * flash::sectorSize + offsetCrc);
+
         auto page = flash::Page{};
-        std::copy((static_cast<Byte const *>(buffer) + i),                      // NOLINT
-                  (static_cast<Byte const *>(buffer) + i + config->prog_size),  // NOLINT
-                  page.begin());
-        flash::ProgramPage(startAddress + i, std::span(page));
+        std::copy_n(static_cast<Byte const *>(buffer) + i,  // NOLINT(*pointer-arithmetic)
+                    config->prog_size,
+                    page.begin());
+
+        const std::uint32_t crc =
+            lfs_crc(initialCrcValue,
+                    static_cast<Byte const *>(buffer) + i,  // NOLINT(*pointer-arithmetic)
+                    config->prog_size);
+        std::memcpy(page.begin() + config->prog_size, &crc, sizeof(crc));
+
+        flash::ProgramPage(startAddress, std::span(page));
         auto waitWhileBusyResult = flash::WaitWhileBusy(pageProgramTimeout);
         if(waitWhileBusyResult.has_error())
         {
@@ -123,9 +160,9 @@ auto Program(lfs_config const * config,
 }
 
 
-auto Erase(lfs_config const * config, lfs_block_t blockNo) -> int
+auto Erase([[maybe_unused]] lfs_config const * config, lfs_block_t blockNo) -> int
 {
-    flash::EraseSector(blockNo * config->block_size);
+    flash::EraseSector(blockNo * flash::sectorSize);
     auto waitWhileBusyResult = flash::WaitWhileBusy(blockEraseTimeout);
     if(waitWhileBusyResult.has_error())
     {

--- a/Sts1CobcSw/FileSystem/LfsMemoryDevice.hpp
+++ b/Sts1CobcSw/FileSystem/LfsMemoryDevice.hpp
@@ -1,11 +1,19 @@
 #pragma once
 
+#include <Sts1CobcSw/Serial/Byte.hpp>
+
 #include <littlefs/lfs.h>
+
+#include <cstdint>
 
 
 namespace sts1cobcsw::fs
 {
-inline constexpr auto lfsCacheSize = 256;
+
+inline constexpr auto eraseValue = 0xFF_b;
+inline constexpr auto initialCrcValue = 0;
+inline constexpr auto crcSize = sizeof(std::uint32_t);
+inline constexpr auto lfsCacheSize = 256 - crcSize;
 // Our longest path should be strlen("/programs/65536.zip.lock") = 25 characters long
 inline constexpr auto maxPathLength = 30;
 extern lfs_config const lfsConfig;

--- a/Sts1CobcSw/FileSystem/LfsMemoryDevice.hpp
+++ b/Sts1CobcSw/FileSystem/LfsMemoryDevice.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <Sts1CobcSw/Serial/Byte.hpp>
 
 #include <littlefs/lfs.h>
 
@@ -9,9 +8,6 @@
 
 namespace sts1cobcsw::fs
 {
-
-inline constexpr auto eraseValue = 0xFF_b;
-inline constexpr auto initialCrcValue = 0;
 inline constexpr auto crcSize = sizeof(std::uint32_t);
 inline constexpr auto lfsCacheSize = 256 - crcSize;
 // Our longest path should be strlen("/programs/65536.zip.lock") = 25 characters long

--- a/Sts1CobcSw/FileSystem/LfsRam.cpp
+++ b/Sts1CobcSw/FileSystem/LfsRam.cpp
@@ -7,10 +7,15 @@
 #include <Sts1CobcSw/FileSystem/LfsRam.hpp>
 #include <Sts1CobcSw/Serial/Byte.hpp>
 
+#include <littlefs/lfs.h>
+#include <littlefs/lfs_util.h>
+
 #include <rodos_no_using_namespace.h>
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
+#include <cstring>
 #include <vector>
 
 
@@ -34,7 +39,10 @@ auto Unlock(lfs_config const * config) -> int;
 
 
 constexpr auto pageSize = 256;
+constexpr auto pageSizeLfs = pageSize - crcSize;
 constexpr auto sectorSize = 4 * 1024;
+constexpr auto sectorSizeLfs = 4 * (1024 - 4 * crcSize);
+constexpr auto memorySizeLfs = 128 * 1024 * (1024 - 4 * crcSize);
 constexpr auto memorySize = 128 * 1024 * 1024;
 
 std::vector<Byte> memory = std::vector<Byte>();
@@ -46,7 +54,7 @@ auto corruptNextWrite = false;
 // littlefs requires the lookaheadBuffer size to be a multiple of 8
 static_assert(lookaheadBuffer.size() % 8 == 0);  // NOLINT(*magic-numbers)
 // littlefs requires the cacheSize to be a multiple of the read_size and prog_size, i.e., pageSize
-static_assert(lfsCacheSize % pageSize == 0);
+static_assert(lfsCacheSize % pageSizeLfs == 0);
 
 lfs_config const lfsConfig = lfs_config{.context = nullptr,
                                         .read = &Read,
@@ -55,10 +63,10 @@ lfs_config const lfsConfig = lfs_config{.context = nullptr,
                                         .sync = &Sync,
                                         .lock = &Lock,
                                         .unlock = &Unlock,
-                                        .read_size = pageSize,
-                                        .prog_size = pageSize,
-                                        .block_size = sectorSize,
-                                        .block_count = memorySize / sectorSize,
+                                        .read_size = pageSizeLfs,
+                                        .prog_size = pageSizeLfs,
+                                        .block_size = sectorSizeLfs,
+                                        .block_count = memorySizeLfs / sectorSizeLfs,
                                         .block_cycles = 200,
                                         .cache_size = readBuffer.size(),
                                         .lookahead_size = lookaheadBuffer.size(),
@@ -69,7 +77,7 @@ lfs_config const lfsConfig = lfs_config{.context = nullptr,
                                         .name_max = maxPathLength,
                                         .file_max = LFS_FILE_MAX,
                                         .attr_max = LFS_ATTR_MAX,
-                                        .metadata_max = sectorSize,
+                                        .metadata_max = sectorSizeLfs,
                                         .inline_max = 0};
 
 auto semaphore = RODOS::Semaphore();
@@ -78,30 +86,74 @@ void (*programFinishedHandler)() = nullptr;
 
 auto Initialize() -> void
 {
-    memory.resize(memorySize, 0xFF_b);  // NOLINT(*magic-numbers*)
+    memory.resize(memorySize, eraseValue);
 }
 
 
 auto Read(lfs_config const * config,
-          lfs_block_t blockNo,
+          lfs_block_t blockNo,  // NOLINT(bugprone-easily-swappable-parameters)
           lfs_off_t offset,
           void * buffer,
           lfs_size_t size) -> int
 {
-    auto start = static_cast<int>(blockNo * config->block_size + offset);
-    std::copy_n(memory.begin() + start, size, static_cast<Byte *>(buffer));
+    // read page for page to check the crc of each one
+    for(lfs_size_t i = 0; i < size; i += config->read_size)
+    {
+        auto const pages = (i + offset) / config->read_size;
+        auto const offsetCrc = pages * pageSize;
+        auto const start = static_cast<size_t>(blockNo * sectorSize + offsetCrc);
+        auto const crcPosition = start + config->read_size;
+
+        // if the page is filled with eraseValue -> page was just erased and the crc is not set
+        if(!std::all_of(memory.begin() + static_cast<int>(start),
+                        memory.begin() + static_cast<int>(crcPosition),
+                        [](Byte byte) { return byte == eraseValue; }))
+        {
+            std::uint32_t crc = {};
+            std::memcpy(&crc, &memory[crcPosition], sizeof(crc));
+
+            const std::uint32_t crcCalculated =
+                lfs_crc(initialCrcValue, &memory[start], config->read_size);
+
+            if(crc != crcCalculated)
+            {
+                return LFS_ERR_CORRUPT;
+            }
+        }
+
+        std::copy_n(memory.begin() + static_cast<int>(start),
+                    config->read_size,
+                    static_cast<Byte *>(buffer) + i);  // NOLINT(*pointer-arithmetic)
+    }
     return 0;
 }
 
 
 auto Program(lfs_config const * config,
-             lfs_block_t blockNo,
+             lfs_block_t blockNo,  // NOLINT(bugprone-easily-swappable-parameters)
              lfs_off_t offset,
              void const * buffer,
              lfs_size_t size) -> int
 {
-    auto start = static_cast<int>(blockNo * config->block_size + offset);
-    std::copy_n(static_cast<Byte const *>(buffer), size, memory.begin() + start);
+    for(lfs_size_t i = 0; i < size; i += config->prog_size)
+    {
+        auto const pages = (i + offset) / config->prog_size;
+        auto const offsetCrc = pages * pageSize;
+        auto const start = static_cast<size_t>(blockNo * sectorSize + offsetCrc);
+
+        // copy data
+        std::copy_n(static_cast<Byte const *>(buffer) + i,  // NOLINT(*pointer-arithmetic)
+                    config->prog_size,
+                    memory.begin() + static_cast<int>(start));
+        const std::uint32_t crc =
+            lfs_crc(initialCrcValue,
+                    static_cast<Byte const *>(buffer) + i,  // NOLINT(*pointer-arithmetic)
+                    config->prog_size);
+
+        // copy crc
+        const std::uint32_t crcPosition = start + config->prog_size;
+        std::memcpy(&memory[crcPosition], &crc, sizeof(crc));
+    }
     if(programFinishedHandler != nullptr)
     {
         programFinishedHandler();
@@ -110,10 +162,10 @@ auto Program(lfs_config const * config,
 }
 
 
-auto Erase(lfs_config const * config, lfs_block_t blockNo) -> int
+auto Erase([[maybe_unused]] lfs_config const * config, lfs_block_t blockNo) -> int
 {
-    auto start = static_cast<int>(blockNo * config->block_size);
-    std::fill_n(memory.begin() + start, config->block_size, 0xFF_b);  // NOLINT(*magic-numbers*)
+    auto start = static_cast<size_t>(blockNo * sectorSize);
+    std::fill_n(memory.begin() + static_cast<int>(start), sectorSize, eraseValue);
     return 0;
 }
 

--- a/Sts1CobcSw/FileSystem/LfsRam.cpp
+++ b/Sts1CobcSw/FileSystem/LfsRam.cpp
@@ -11,7 +11,6 @@
 
 #include <algorithm>
 #include <array>
-#include <span>
 #include <vector>
 
 
@@ -37,10 +36,6 @@ auto Unlock(lfs_config const * config) -> int;
 constexpr auto pageSize = 256;
 constexpr auto sectorSize = 4 * 1024;
 constexpr auto memorySize = 128 * 1024 * 1024;
-// only used for testing write errors. This pattern will fail in ram when SimulateFailOnNextWrite is
-// called
-constexpr auto corruptionPattern =
-    std::array<Byte, 4>{Byte{0xC0}, Byte{0xFF}, Byte{0xEE}, Byte{0xEE}};
 
 std::vector<Byte> memory = std::vector<Byte>();
 auto readBuffer = std::array<Byte, lfsCacheSize>{};
@@ -78,6 +73,7 @@ lfs_config const lfsConfig = lfs_config{.context = nullptr,
                                         .inline_max = 0};
 
 auto semaphore = RODOS::Semaphore();
+void (*programFinishedHandler)() = nullptr;
 
 
 auto Initialize() -> void
@@ -85,10 +81,6 @@ auto Initialize() -> void
     memory.resize(memorySize, 0xFF_b);  // NOLINT(*magic-numbers*)
 }
 
-auto SimulateFailOnNextWrite() -> void
-{
-    corruptNextWrite = true;
-}
 
 auto Read(lfs_config const * config,
           lfs_block_t blockNo,
@@ -101,6 +93,7 @@ auto Read(lfs_config const * config,
     return 0;
 }
 
+
 auto Program(lfs_config const * config,
              lfs_block_t blockNo,
              lfs_off_t offset,
@@ -108,22 +101,10 @@ auto Program(lfs_config const * config,
              lfs_size_t size) -> int
 {
     auto start = static_cast<int>(blockNo * config->block_size + offset);
-
-
     std::copy_n(static_cast<Byte const *>(buffer), size, memory.begin() + start);
-    // for testing only to trigger a file corruption
-    if(corruptNextWrite)
+    if(programFinishedHandler != nullptr)
     {
-        auto bufferSpan = std::span(memory.begin() + start, size);
-        for(uint32_t i = 0; i < size - corruptionPattern.size(); i++)
-        {
-            if(memcmp(&bufferSpan[i], &corruptionPattern, corruptionPattern.size()) == 0)
-            {
-                const Byte corruptedByte{0xDD};
-                bufferSpan[i] = corruptedByte;
-                corruptNextWrite = false;
-            }
-        }
+        programFinishedHandler();
     }
     return 0;
 }
@@ -154,5 +135,11 @@ auto Unlock([[maybe_unused]] lfs_config const * config) -> int
 {
     semaphore.leave();
     return 0;
+}
+
+
+auto SetProgramFinishedHandler(void (*handler)()) -> void
+{
+    programFinishedHandler = handler;
 }
 }

--- a/Sts1CobcSw/FileSystem/LfsRam.cpp
+++ b/Sts1CobcSw/FileSystem/LfsRam.cpp
@@ -4,6 +4,7 @@
 //! This is useful for testing the file system without using a real flash memory.
 
 #include <Sts1CobcSw/FileSystem/LfsMemoryDevice.hpp>  // IWYU pragma: associated
+#include <Sts1CobcSw/FileSystem/LfsRam.hpp>
 #include <Sts1CobcSw/Serial/Byte.hpp>
 
 #include <rodos_no_using_namespace.h>
@@ -36,7 +37,7 @@ constexpr auto pageSize = 256;
 constexpr auto sectorSize = 4 * 1024;
 constexpr auto memorySize = 128 * 1024 * 1024;
 
-auto memory = std::vector<Byte>();
+std::vector<Byte> memory = std::vector<Byte>();
 auto readBuffer = std::array<Byte, lfsCacheSize>{};
 auto programBuffer = decltype(readBuffer){};
 auto lookaheadBuffer = std::array<Byte, 64>{};  // NOLINT(*magic-numbers)

--- a/Sts1CobcSw/FileSystem/LfsRam.hpp
+++ b/Sts1CobcSw/FileSystem/LfsRam.hpp
@@ -7,4 +7,5 @@
 namespace sts1cobcsw::fs
 {
 extern std::vector<Byte> memory;
+void SimulateFailOnNextWrite();
 }

--- a/Sts1CobcSw/FileSystem/LfsRam.hpp
+++ b/Sts1CobcSw/FileSystem/LfsRam.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <vector>
+
+#include "Sts1CobcSw/Serial/Byte.hpp"
+
+namespace sts1cobcsw::fs
+{
+extern std::vector<Byte> memory;
+}

--- a/Sts1CobcSw/FileSystem/LfsRam.hpp
+++ b/Sts1CobcSw/FileSystem/LfsRam.hpp
@@ -1,11 +1,15 @@
 #pragma once
 
+
+#include <Sts1CobcSw/Serial/Byte.hpp>
+
 #include <vector>
 
-#include "Sts1CobcSw/Serial/Byte.hpp"
 
 namespace sts1cobcsw::fs
 {
 extern std::vector<Byte> memory;
-void SimulateFailOnNextWrite();
+
+
+auto SetProgramFinishedHandler(void (*handler)()) -> void;
 }

--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -103,7 +103,7 @@ add_program(LfsWrapper LfsWrapper.test.cpp UnitTestThread.cpp)
 target_link_libraries(
     Sts1CobcSwTests_LfsWrapper PRIVATE rodos::rodos littlefs::littlefs Sts1CobcSw_FileSystem
 )
-add_test(NAME LfsWrapper COMMAND Sts1CobcSwTests_FramRingArray)
+add_test(NAME LfsWrapper COMMAND Sts1CobcSwTests_LfsWrapper)
 
 add_program(PersistentVariables PersistentVariables.test.cpp UnitTestThread.cpp)
 target_link_libraries(

--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -97,13 +97,14 @@ add_test(NAME FramVector COMMAND Sts1CobcSwTests_FramVector)
 add_program(LfsRam LfsRam.test.cpp UnitTestThread.cpp)
 target_link_libraries(
     Sts1CobcSwTests_LfsRam PRIVATE rodos::rodos littlefs::littlefs Sts1CobcSw_FileSystem
-                                   Sts1CobcSw_Utility
+                                   Sts1CobcSw_Serial
 )
 add_test(NAME LfsRam COMMAND Sts1CobcSwTests_LfsRam)
 
 add_program(LfsWrapper LfsWrapper.test.cpp UnitTestThread.cpp)
 target_link_libraries(
-    Sts1CobcSwTests_LfsWrapper PRIVATE rodos::rodos littlefs::littlefs Sts1CobcSw_FileSystem
+    Sts1CobcSwTests_LfsWrapper PRIVATE rodos::rodos etl::etl littlefs::littlefs
+                                       Sts1CobcSw_FileSystem Sts1CobcSw_Serial Sts1CobcSw_Utility
 )
 add_test(NAME LfsWrapper COMMAND Sts1CobcSwTests_LfsWrapper)
 

--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -97,6 +97,7 @@ add_test(NAME FramVector COMMAND Sts1CobcSwTests_FramVector)
 add_program(LfsRam LfsRam.test.cpp UnitTestThread.cpp)
 target_link_libraries(
     Sts1CobcSwTests_LfsRam PRIVATE rodos::rodos littlefs::littlefs Sts1CobcSw_FileSystem
+                                   Sts1CobcSw_Utility
 )
 
 add_program(LfsWrapper LfsWrapper.test.cpp UnitTestThread.cpp)

--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -99,6 +99,7 @@ target_link_libraries(
     Sts1CobcSwTests_LfsRam PRIVATE rodos::rodos littlefs::littlefs Sts1CobcSw_FileSystem
                                    Sts1CobcSw_Utility
 )
+add_test(NAME LfsRam COMMAND Sts1CobcSwTests_LfsRam)
 
 add_program(LfsWrapper LfsWrapper.test.cpp UnitTestThread.cpp)
 target_link_libraries(

--- a/Tests/UnitTests/LfsRam.test.cpp
+++ b/Tests/UnitTests/LfsRam.test.cpp
@@ -2,18 +2,27 @@
 
 #include <Sts1CobcSw/FileSystem/LfsMemoryDevice.hpp>
 #include <Sts1CobcSw/FileSystem/LfsRam.hpp>
-#include <Sts1CobcSw/Utility/Span.hpp>
+#include <Sts1CobcSw/Serial/Byte.hpp>
 
 #include <littlefs/lfs.h>
 
-#include <rodos_no_using_namespace.h>
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <span>
+#include <string>
+#include <vector>
+
+
+namespace fs = sts1cobcsw::fs;
+using sts1cobcsw::operator""_b;
+
+
+auto TryToCorruptDataInMemory(std::span<const sts1cobcsw::Byte> dataToCorrupt) -> bool;
 
 
 auto RunUnitTest() -> void
 {
-    namespace fs = sts1cobcsw::fs;
-    using sts1cobcsw::operator""_b;
-
     fs::Initialize();
     auto lfs = lfs_t{};
     auto errorCode = lfs_format(&lfs, &fs::lfsConfig);
@@ -68,25 +77,46 @@ auto RunUnitTest() -> void
         errorCode = lfs_file_open(&lfs, &file, filePath, LFS_O_WRONLY | LFS_O_CREAT);
         Require(errorCode == 0);
 
-        // The first time the pattern 0xC0FFEEEE is written to memory it is replaced with
-        // 0xDDFFEEEE. Subsequent writes will not be replaced. This is done on the device level to
-        // simulate a write/memory fault. Littlefs should detect this and automatically write to a
-        // different location, so lfs_file_write() does not fail.
-        fs::SimulateFailOnNextWrite();
-        static constexpr auto corruptionPattern = std::array{0xC0_b, 0xFF_b, 0xEE_b, 0xEE_b};
-        errorCode = lfs_file_write(&lfs, &file, corruptionPattern.data(), corruptionPattern.size());
-        Require(errorCode == static_cast<int>(corruptionPattern.size()));
+        // The first time 0xC0FFEEEE is written to memory it is corrupted (a bit is flipped).
+        // Subsequent writes will not be replaced. This simulates a write/memory fault. Littlefs
+        // should detect this and automatically write to a different location, so lfs_file_write()
+        // does not fail.
+        static constexpr auto writeData = std::array{0xC0_b, 0xFF_b, 0xEE_b, 0xEE_b};
+        fs::SetProgramFinishedHandler(
+            []()
+            {
+                static auto corruptNextWrite = true;
+                if(corruptNextWrite)
+                {
+                    auto dataWasFoundAndCorrupted = TryToCorruptDataInMemory(writeData);
+                    corruptNextWrite = not dataWasFoundAndCorrupted;
+                }
+            });
+        errorCode = lfs_file_write(&lfs, &file, writeData.data(), writeData.size());
+        Require(errorCode == static_cast<int>(writeData.size()));
 
         errorCode = lfs_file_close(&lfs, &file);
         Require(errorCode == 0);
+        // Reset the program finished handler after closing the file because that is when the data
+        // is really written to memory
+        fs::SetProgramFinishedHandler(nullptr);
         errorCode = lfs_file_open(&lfs, &file, filePath, LFS_O_RDONLY);
         Require(errorCode == 0);
 
+        // Check that both 0xC0FFEEEE and 0x40FFEEEE are in memory
+        auto it =
+            std::search(fs::memory.begin(), fs::memory.end(), writeData.begin(), writeData.end());
+        Require(it != fs::memory.end());
+        auto corruptedData = std::array{0x40_b, 0xFF_b, 0xEE_b, 0xEE_b};
+        it = std::search(
+            fs::memory.begin(), fs::memory.end(), corruptedData.begin(), corruptedData.end());
+        Require(it != fs::memory.end());
+
         // Since littlefs detected and corrected the write fault, we should read the correct data
-        auto readData = decltype(corruptionPattern){};
+        auto readData = decltype(writeData){};
         errorCode = lfs_file_read(&lfs, &file, readData.data(), readData.size());
         Require(errorCode == static_cast<int>(readData.size()));
-        Require(readData == corruptionPattern);
+        Require(readData == writeData);
 
         errorCode = lfs_file_close(&lfs, &file);
         Require(errorCode == 0);
@@ -100,9 +130,9 @@ auto RunUnitTest() -> void
         errorCode = lfs_mount(&lfs, &fs::lfsConfig);
         Require(errorCode == 0);
 
-        auto const * filePath = "/BitFlip";
+        static auto const filePath = "/BitFlip" + std::to_string(i);
         auto file = lfs_file_t{};
-        errorCode = lfs_file_open(&lfs, &file, filePath, LFS_O_WRONLY | LFS_O_CREAT);
+        errorCode = lfs_file_open(&lfs, &file, filePath.c_str(), LFS_O_WRONLY | LFS_O_CREAT);
         Require(errorCode == 0);
 
         auto writeData = std::array{0xDE_b, 0xAD_b, 0xBE_b, 0xEF_b};
@@ -116,32 +146,39 @@ auto RunUnitTest() -> void
             errorCode = lfs_unmount(&lfs);
             Require(errorCode == 0);
         }
-
-        // Search for the written data in memory and flip a bit
-        auto it =
-            std::search(fs::memory.begin(), fs::memory.end(), writeData.begin(), writeData.end());
-        Require(it != fs::memory.end());
-        *it ^= 0x08_b;
-
+        TryToCorruptDataInMemory(writeData);
         if(i == 0)
         {
             errorCode = lfs_mount(&lfs, &fs::lfsConfig);
             Require(errorCode == 0);
         }
-        errorCode = lfs_file_open(&lfs, &file, filePath, LFS_O_RDONLY);
+        errorCode = lfs_file_open(&lfs, &file, filePath.c_str(), LFS_O_RDONLY);
         Require(errorCode == 0);
 
-        // File can be read but it is empty
+        // File is empty, but it can be read (i.e. lfs_file_read() does not fail)
+        auto size = lfs_file_size(&lfs, &file);
+        Require(size == 0);
         auto readData = decltype(writeData){};
         errorCode = lfs_file_read(&lfs, &file, readData.data(), readData.size());
         Require(errorCode == 0);
         Require(readData != writeData);
-        auto size = lfs_file_size(&lfs, &file);
-        Require(size == 0);
 
         errorCode = lfs_file_close(&lfs, &file);
         Require(errorCode == 0);
         errorCode = lfs_unmount(&lfs);
         Require(errorCode == 0);
     }
+}
+
+
+auto TryToCorruptDataInMemory(std::span<const sts1cobcsw::Byte> dataToCorrupt) -> bool
+{
+    auto it = std::search(
+        fs::memory.begin(), fs::memory.end(), dataToCorrupt.begin(), dataToCorrupt.end());
+    if(it == fs::memory.end())
+    {
+        return false;
+    }
+    *it ^= 0x80_b;
+    return true;
 }

--- a/Tests/UnitTests/LfsRam.test.cpp
+++ b/Tests/UnitTests/LfsRam.test.cpp
@@ -1,47 +1,147 @@
 #include <Tests/UnitTests/UnitTestThread.hpp>
 
 #include <Sts1CobcSw/FileSystem/LfsMemoryDevice.hpp>
+#include <Sts1CobcSw/FileSystem/LfsRam.hpp>
+#include <Sts1CobcSw/Utility/Span.hpp>
 
 #include <littlefs/lfs.h>
+
+#include <rodos_no_using_namespace.h>
 
 
 auto RunUnitTest() -> void
 {
-    sts1cobcsw::fs::Initialize();
+    namespace fs = sts1cobcsw::fs;
+    using sts1cobcsw::operator""_b;
+
+    fs::Initialize();
     auto lfs = lfs_t{};
-    auto errorCode = lfs_format(&lfs, &sts1cobcsw::fs::lfsConfig);
-    Require(errorCode == 0);
-    errorCode = lfs_mount(&lfs, &sts1cobcsw::fs::lfsConfig);
+    auto errorCode = lfs_format(&lfs, &fs::lfsConfig);
     Require(errorCode == 0);
 
-    auto const * directoryPath = "MyFolder";
-    errorCode = lfs_mkdir(&lfs, directoryPath);
-    Require(errorCode == 0);
+    // Test without memory corruption or faults
+    {
+        errorCode = lfs_mount(&lfs, &fs::lfsConfig);
+        Require(errorCode == 0);
 
-    auto const * filePath = "MyFolder/MyFile";
-    auto file = lfs_file_t{};
-    errorCode = lfs_file_open(&lfs, &file, filePath, LFS_O_WRONLY | LFS_O_CREAT);
-    Require(errorCode == 0);
+        auto const * directoryPath = "MyFolder";
+        errorCode = lfs_mkdir(&lfs, directoryPath);
+        Require(errorCode == 0);
 
-    int number = 123;
-    errorCode = lfs_file_write(&lfs, &file, &number, sizeof(number));
-    Require(errorCode == sizeof(number));
+        auto const * filePath = "MyFolder/MyFile";
+        auto file = lfs_file_t{};
+        errorCode = lfs_file_open(&lfs, &file, filePath, LFS_O_WRONLY | LFS_O_CREAT);
+        Require(errorCode == 0);
 
-    errorCode = lfs_file_close(&lfs, &file);
-    Require(errorCode == 0);
-    errorCode = lfs_unmount(&lfs);
-    Require(errorCode == 0);
+        int number = 123;
+        errorCode = lfs_file_write(&lfs, &file, &number, sizeof(number));
+        Require(errorCode == sizeof(number));
 
-    errorCode = lfs_mount(&lfs, &sts1cobcsw::fs::lfsConfig);
-    Require(errorCode == 0);
-    errorCode = lfs_file_open(&lfs, &file, filePath, LFS_O_RDONLY);
-    Require(errorCode == 0);
+        errorCode = lfs_file_close(&lfs, &file);
+        Require(errorCode == 0);
+        errorCode = lfs_unmount(&lfs);
+        Require(errorCode == 0);
 
-    int readNumber = 0;
-    errorCode = lfs_file_read(&lfs, &file, &readNumber, sizeof(number));
-    Require(errorCode == sizeof(number));
-    Require(readNumber == number);
+        errorCode = lfs_mount(&lfs, &fs::lfsConfig);
+        Require(errorCode == 0);
+        errorCode = lfs_file_open(&lfs, &file, filePath, LFS_O_RDONLY);
+        Require(errorCode == 0);
 
-    errorCode = lfs_file_close(&lfs, &file);
-    Require(errorCode == 0);
+        int readNumber = 0;
+        errorCode = lfs_file_read(&lfs, &file, &readNumber, sizeof(number));
+        Require(errorCode == sizeof(number));
+        Require(readNumber == number);
+
+        errorCode = lfs_file_close(&lfs, &file);
+        Require(errorCode == 0);
+        errorCode = lfs_unmount(&lfs);
+        Require(errorCode == 0);
+    }
+
+    // Test with faulty write
+    {
+        errorCode = lfs_mount(&lfs, &fs::lfsConfig);
+        Require(errorCode == 0);
+
+        auto const * filePath = "/FaultyWrite";
+        auto file = lfs_file_t{};
+        errorCode = lfs_file_open(&lfs, &file, filePath, LFS_O_WRONLY | LFS_O_CREAT);
+        Require(errorCode == 0);
+
+        // The first time the pattern 0xC0FFEEEE is written to memory it is replaced with
+        // 0xDDFFEEEE. Subsequent writes will not be replaced. This is done on the device level to
+        // simulate a write/memory fault. Littlefs should detect this and automatically write to a
+        // different location, so lfs_file_write() does not fail.
+        fs::SimulateFailOnNextWrite();
+        static constexpr auto corruptionPattern = std::array{0xC0_b, 0xFF_b, 0xEE_b, 0xEE_b};
+        errorCode = lfs_file_write(&lfs, &file, corruptionPattern.data(), corruptionPattern.size());
+        Require(errorCode == static_cast<int>(corruptionPattern.size()));
+
+        errorCode = lfs_file_close(&lfs, &file);
+        Require(errorCode == 0);
+        errorCode = lfs_file_open(&lfs, &file, filePath, LFS_O_RDONLY);
+        Require(errorCode == 0);
+
+        // Since littlefs detected and corrected the write fault, we should read the correct data
+        auto readData = decltype(corruptionPattern){};
+        errorCode = lfs_file_read(&lfs, &file, readData.data(), readData.size());
+        Require(errorCode == static_cast<int>(readData.size()));
+        Require(readData == corruptionPattern);
+
+        errorCode = lfs_file_close(&lfs, &file);
+        Require(errorCode == 0);
+        errorCode = lfs_unmount(&lfs);
+        Require(errorCode == 0);
+    }
+
+    // Test with bit flip (once while mounted and once while unmounted)
+    for(auto i = 0; i < 2; ++i)
+    {
+        errorCode = lfs_mount(&lfs, &fs::lfsConfig);
+        Require(errorCode == 0);
+
+        auto const * filePath = "/BitFlip";
+        auto file = lfs_file_t{};
+        errorCode = lfs_file_open(&lfs, &file, filePath, LFS_O_WRONLY | LFS_O_CREAT);
+        Require(errorCode == 0);
+
+        auto writeData = std::array{0xDE_b, 0xAD_b, 0xBE_b, 0xEF_b};
+        errorCode = lfs_file_write(&lfs, &file, writeData.data(), writeData.size());
+        Require(errorCode == static_cast<int>(writeData.size()));
+
+        errorCode = lfs_file_close(&lfs, &file);
+        Require(errorCode == 0);
+        if(i == 0)
+        {
+            errorCode = lfs_unmount(&lfs);
+            Require(errorCode == 0);
+        }
+
+        // Search for the written data in memory and flip a bit
+        auto it =
+            std::search(fs::memory.begin(), fs::memory.end(), writeData.begin(), writeData.end());
+        Require(it != fs::memory.end());
+        *it ^= 0x08_b;
+
+        if(i == 0)
+        {
+            errorCode = lfs_mount(&lfs, &fs::lfsConfig);
+            Require(errorCode == 0);
+        }
+        errorCode = lfs_file_open(&lfs, &file, filePath, LFS_O_RDONLY);
+        Require(errorCode == 0);
+
+        // File can be read but it is empty
+        auto readData = decltype(writeData){};
+        errorCode = lfs_file_read(&lfs, &file, readData.data(), readData.size());
+        Require(errorCode == 0);
+        Require(readData != writeData);
+        auto size = lfs_file_size(&lfs, &file);
+        Require(size == 0);
+
+        errorCode = lfs_file_close(&lfs, &file);
+        Require(errorCode == 0);
+        errorCode = lfs_unmount(&lfs);
+        Require(errorCode == 0);
+    }
 }

--- a/Tests/UnitTests/LfsWrapper.test.cpp
+++ b/Tests/UnitTests/LfsWrapper.test.cpp
@@ -2,6 +2,7 @@
 
 #include <Sts1CobcSw/FileSystem/ErrorsAndResult.hpp>
 #include <Sts1CobcSw/FileSystem/LfsMemoryDevice.hpp>
+#include <Sts1CobcSw/FileSystem/LfsRam.hpp>
 #include <Sts1CobcSw/FileSystem/LfsWrapper.hpp>
 #include <Sts1CobcSw/Serial/Byte.hpp>
 #include <Sts1CobcSw/Utility/Span.hpp>
@@ -12,6 +13,10 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <vector>
 
 
 using sts1cobcsw::Byte;
@@ -19,6 +24,10 @@ using sts1cobcsw::Span;
 using sts1cobcsw::fs::Path;
 using sts1cobcsw::operator""_b;  // NOLINT(misc-unused-using-decls)
 
+constexpr auto corruptionPattern =
+    std::array<Byte, 4>{Byte{0xDE}, Byte{0xAD}, Byte{0xBE}, Byte{0xFF}};
+
+auto ReplaceMemoryPattern() -> bool;
 
 auto RunUnitTest() -> void
 {
@@ -28,6 +37,7 @@ auto RunUnitTest() -> void
     auto mountResult = sts1cobcsw::fs::Mount();
     Require(not mountResult.has_error());
 
+    {  // success run with no corruption
     auto filePath = Path("/MyFile");
     auto openResult = sts1cobcsw::fs::Open(filePath, LFS_O_WRONLY | LFS_O_CREAT);
     Require(openResult.has_value());
@@ -74,7 +84,62 @@ auto RunUnitTest() -> void
 
     closeResult = readableFile.Close();
     Require(not closeResult.has_error());
+    }
+
+    {  // run with bit flip
+        auto filePath = Path("/BitCorruption");
+        auto openResult = sts1cobcsw::fs::Open(filePath, LFS_O_WRONLY | LFS_O_CREAT);
+        Require(openResult.has_value());
+        auto & file = openResult.value();
+
+        auto writeData = std::array{0xDE_b, 0xAD_b, 0xBE_b, 0xFF_b};
+        auto writeResult = file.Write(Span(writeData));
+        Require(writeResult.has_value());
+        Require(writeResult.value() == sizeof(corruptionPattern));
+
+        auto closeResult = file.Close();
+        Require(not closeResult.has_error());
+
+        auto unmountResult = sts1cobcsw::fs::Unmount();
+        Require(not unmountResult.has_error());
+
+        Require(ReplaceMemoryPattern());  // corrupt this file
+
+        auto corruptedMountResult = sts1cobcsw::fs::Mount();
+        Require(not corruptedMountResult.has_error());
+
+        openResult = sts1cobcsw::fs::Open(filePath, LFS_O_RDONLY);
+        Require(not openResult.has_error());
+        auto & corruptedFile = openResult.value();
+
+        auto sizeResult = corruptedFile.Size();
+        Require(sizeResult.has_value());
+        Require(sizeResult.value() == 0);  // file cant be read and is empty!
+
+        auto readData = std::array{0x11_b, 0x22_b, 0x33_b, 0x44_b};
+        auto readResult = corruptedFile.Read(Span(&readData));
+        Require(readResult.has_value());
+        Require(readResult.value() == 0);
+        Require(readData != writeData);
+    }
 
     auto unmountResult = sts1cobcsw::fs::Unmount();
     Require(not unmountResult.has_error());
+}
+
+
+auto ReplaceMemoryPattern() -> bool
+{
+    auto bufferSpan = std::span(::sts1cobcsw::fs::memory.begin(), ::sts1cobcsw::fs::memory.size());
+    for(uint32_t i = 0; i < bufferSpan.size() - corruptionPattern.size(); i++)
+    {
+        if(memcmp(&bufferSpan[i], &corruptionPattern, corruptionPattern.size()) == 0)
+        {
+            const Byte corruptedByte{0xDD};
+            bufferSpan[i] = corruptedByte;
+            return true;
+        }
+    }
+
+    return false;
 }


### PR DESCRIPTION
Fixes #217

The littlefs tests now also check what happens with faulty writes and bit flips.