### PR TITLE
Add interrupt capabilities to `GpioPin`

### DIFF
--- a/Sts1CobcSw/CobcSoftware/EduHeartbeatThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/EduHeartbeatThread.cpp
@@ -40,9 +40,9 @@ public:
 private:
     void init() override
     {
-        eduHeartbeatGpioPin.Direction(hal::PinDirection::in);
-        ledGpioPin.Direction(hal::PinDirection::out);
-        epsChargingGpioPin.Direction(hal::PinDirection::out);
+        eduHeartbeatGpioPin.SetDirection(hal::PinDirection::in);
+        ledGpioPin.SetDirection(hal::PinDirection::out);
+        epsChargingGpioPin.SetDirection(hal::PinDirection::out);
         ledGpioPin.Reset();
         epsChargingGpioPin.Reset();
         // edu.Initialize();

--- a/Sts1CobcSw/CobcSoftware/EduListenerThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/EduListenerThread.cpp
@@ -35,7 +35,7 @@ public:
 private:
     void init() override
     {
-        eduUpdateGpioPin.Direction(hal::PinDirection::in);
+        eduUpdateGpioPin.SetDirection(hal::PinDirection::in);
     }
 
 

--- a/Sts1CobcSw/CobcSoftware/EduPowerManagementThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/EduPowerManagementThread.cpp
@@ -39,7 +39,7 @@ public:
 private:
     void init() override
     {
-        epsBatteryGoodGpioPin.Direction(hal::PinDirection::in);
+        epsBatteryGoodGpioPin.SetDirection(hal::PinDirection::in);
     }
 
 

--- a/Sts1CobcSw/Edu/Edu.cpp
+++ b/Sts1CobcSw/Edu/Edu.cpp
@@ -86,7 +86,7 @@ auto FlushUartReceiveBuffer() -> void;
 //! @brief  Must be called in an init() function of a thread.
 auto Initialize() -> void
 {
-    eduEnableGpioPin.Direction(hal::PinDirection::out);
+    eduEnableGpioPin.SetDirection(hal::PinDirection::out);
     persistentVariables.template Load<"eduShouldBePowered">() ? TurnOn() : TurnOff();
 }
 

--- a/Sts1CobcSw/Hal/CMakeLists.txt
+++ b/Sts1CobcSw/Hal/CMakeLists.txt
@@ -2,10 +2,11 @@ target_sources(Sts1CobcSw_Hal PRIVATE Spi.cpp)
 target_compile_definitions(Sts1CobcSw_Hal PUBLIC HW_VERSION=${HW_VERSION})
 target_link_libraries(
     Sts1CobcSw_Hal PUBLIC rodos::without_main_on_linux Sts1CobcSw_Outcome Sts1CobcSw_RodosTime
+                          Sts1CobcSw_Vocabulary
 )
 target_link_libraries(Sts1CobcSw_Hal PRIVATE strong_type::strong_type)
 if(CMAKE_SYSTEM_NAME STREQUAL Generic)
-    target_sources(Sts1CobcSw_Hal PRIVATE HardwareSpi.cpp Uart.cpp)
+    target_sources(Sts1CobcSw_Hal PRIVATE GpioPin.cpp HardwareSpi.cpp Uart.cpp)
     target_link_libraries(Sts1CobcSw_Hal PRIVATE etl::etl)
 else()
     target_sources(Sts1CobcSw_Hal PRIVATE SpiMock.cpp)

--- a/Sts1CobcSw/Hal/GpioPin.cpp
+++ b/Sts1CobcSw/Hal/GpioPin.cpp
@@ -1,0 +1,50 @@
+#include <Sts1CobcSw/Hal/GpioPin.hpp>
+#include <Sts1CobcSw/RodosTime/RodosTime.hpp>
+
+
+namespace sts1cobcsw::hal
+{
+auto GpioPin::SetInterruptSensitivity(InterruptSensitivity interruptSensitivity) -> void
+{
+    auto sensitivity =
+        interruptSensitivity == InterruptSensitivity::bothEdges    ? RODOS::GPIO_IRQ_SENS_BOTH
+        : interruptSensitivity == InterruptSensitivity::risingEdge ? RODOS::GPIO_IRQ_SENS_RISING
+                                                                   : RODOS::GPIO_IRQ_SENS_FALLING;
+    pin_.config(RODOS::GPIO_CFG_IRQ_SENSITIVITY, sensitivity);
+}
+
+
+auto GpioPin::SuspendUntilInterrupt(Duration timeout) -> Result<void>
+{
+    auto reactivationTime = CurrentRodosTime() + timeout;
+    pin_.suspendUntilDataReady(value_of(reactivationTime));
+    if(CurrentRodosTime() >= reactivationTime)
+    {
+        return ErrorCode::timeout;
+    }
+    return outcome_v2::success();
+}
+
+
+auto GpioPin::SetInterruptHandler(void (*handler)()) -> void
+{
+    if(handler == nullptr)
+    {
+        pin_.setIoEventReceiver(nullptr);
+    }
+    else
+    {
+        eventReceiver_.SetInterruptHandler(handler);
+        pin_.setIoEventReceiver(&eventReceiver_);
+    }
+}
+
+
+auto GpioPin::GpioEventReceiver::onDataReady() -> void
+{
+    if(interruptHandler_ != nullptr)
+    {
+        interruptHandler_();
+    }
+}
+}

--- a/Sts1CobcSw/Hal/GpioPin.hpp
+++ b/Sts1CobcSw/Hal/GpioPin.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 
+#include <Sts1CobcSw/Outcome/Outcome.hpp>
+#include <Sts1CobcSw/Vocabulary/Time.hpp>
+
 #include <rodos_no_using_namespace.h>
 
 #include <cstdint>
@@ -29,6 +32,14 @@ enum class PinState
 };
 
 
+enum class InterruptSensitivity
+{
+    bothEdges = 0,
+    risingEdge,
+    fallingEdge,
+};
+
+
 class GpioPin
 {
 public:
@@ -36,14 +47,34 @@ public:
     // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
     GpioPin(RODOS::GPIO_PIN pinIndex);
 
+    // TODO: Rename Direction(), ... to SetDirection(), ...
     auto Direction(PinDirection pinDirection) -> void;
     auto OutputType(PinOutputType pinOutputType) -> void;
     auto Set() -> void;
     auto Reset() -> void;
+    auto SetInterruptSensitivity(InterruptSensitivity interruptSensitivity) -> void;
+    auto EnableInterrupts() -> void;
+    auto DisableInterrupts() -> void;
+    auto ResetInterruptStatus() -> void;
+    auto SuspendUntilInterrupt(Duration timeout) -> Result<void>;
+    auto SetInterruptHandler(void (*handler)()) -> void;
     [[nodiscard]] auto Read() const -> PinState;
+    [[nodiscard]] auto InterruptOccurred() const -> bool;
+
 
 private:
+    class GpioEventReceiver : public RODOS::IOEventReceiver
+    {
+    public:
+        auto SetInterruptHandler(void (*handler)()) -> void;
+        auto onDataReady() -> void override;
+
+    private:
+        void (*interruptHandler_)() = nullptr;
+    };
+
     mutable RODOS::HAL_GPIO pin_;
+    GpioEventReceiver eventReceiver_;
 };
 }
 

--- a/Sts1CobcSw/Hal/GpioPin.hpp
+++ b/Sts1CobcSw/Hal/GpioPin.hpp
@@ -47,17 +47,18 @@ public:
     // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
     GpioPin(RODOS::GPIO_PIN pinIndex);
 
-    // TODO: Rename Direction(), ... to SetDirection(), ...
-    auto Direction(PinDirection pinDirection) -> void;
-    auto OutputType(PinOutputType pinOutputType) -> void;
+    auto SetDirection(PinDirection pinDirection) -> void;
+    auto SetOutputType(PinOutputType pinOutputType) -> void;
     auto Set() -> void;
     auto Reset() -> void;
+
     auto SetInterruptSensitivity(InterruptSensitivity interruptSensitivity) -> void;
     auto EnableInterrupts() -> void;
     auto DisableInterrupts() -> void;
     auto ResetInterruptStatus() -> void;
     auto SuspendUntilInterrupt(Duration timeout) -> Result<void>;
     auto SetInterruptHandler(void (*handler)()) -> void;
+
     [[nodiscard]] auto Read() const -> PinState;
     [[nodiscard]] auto InterruptOccurred() const -> bool;
 

--- a/Sts1CobcSw/Hal/GpioPin.ipp
+++ b/Sts1CobcSw/Hal/GpioPin.ipp
@@ -37,8 +37,38 @@ inline auto GpioPin::Reset() -> void
 }
 
 
+inline auto GpioPin::EnableInterrupts() -> void
+{
+    pin_.interruptEnable(true);
+}
+
+
+inline auto GpioPin::DisableInterrupts() -> void
+{
+    pin_.interruptEnable(false);
+}
+
+
+inline auto GpioPin::ResetInterruptStatus() -> void
+{
+    pin_.resetInterruptEventStatus();
+}
+
+
 inline auto GpioPin::Read() const -> PinState
 {
     return pin_.readPins() == 0 ? PinState::reset : PinState::set;
+}
+
+
+inline auto GpioPin::InterruptOccurred() const -> bool
+{
+    return pin_.isDataReady();
+}
+
+
+inline auto GpioPin::GpioEventReceiver::SetInterruptHandler(void (*handler)()) -> void
+{
+    interruptHandler_ = handler;
 }
 }

--- a/Sts1CobcSw/Hal/GpioPin.ipp
+++ b/Sts1CobcSw/Hal/GpioPin.ipp
@@ -11,14 +11,14 @@ inline GpioPin::GpioPin(RODOS::GPIO_PIN pinIndex) : pin_(pinIndex)
 }
 
 
-inline auto GpioPin::Direction(PinDirection pinDirection) -> void
+inline auto GpioPin::SetDirection(PinDirection pinDirection) -> void
 {
     pin_.reset();
     pin_.init(pinDirection == PinDirection::out, 1, 0);
 }
 
 
-inline auto GpioPin::OutputType(PinOutputType pinOutputType) -> void
+inline auto GpioPin::SetOutputType(PinOutputType pinOutputType) -> void
 {
     pin_.config(RODOS::GPIO_CFG_OPENDRAIN_ENABLE,
                 pinOutputType == PinOutputType::openDrain ? 1U : 0U);

--- a/Sts1CobcSw/Periphery/Eps.cpp
+++ b/Sts1CobcSw/Periphery/Eps.cpp
@@ -116,11 +116,11 @@ auto ResetAdc(hal::GpioPin * adcCsPin, ResetType resetType) -> void;
 
 auto InitializeAdcs() -> void
 {
-    adc4CsGpioPin.Direction(hal::PinDirection::out);
+    adc4CsGpioPin.SetDirection(hal::PinDirection::out);
     adc4CsGpioPin.Set();
-    adc5CsGpioPin.Direction(hal::PinDirection::out);
+    adc5CsGpioPin.SetDirection(hal::PinDirection::out);
     adc5CsGpioPin.Set();
-    adc6CsGpioPin.Direction(hal::PinDirection::out);
+    adc6CsGpioPin.SetDirection(hal::PinDirection::out);
     adc6CsGpioPin.Set();
 
     static constexpr auto baudrate = 6'000'000;

--- a/Sts1CobcSw/Periphery/Flash.cpp
+++ b/Sts1CobcSw/Periphery/Flash.cpp
@@ -90,9 +90,9 @@ template<std::endian endianness>
 
 auto Initialize() -> void
 {
-    csGpioPin.Direction(hal::PinDirection::out);
+    csGpioPin.SetDirection(hal::PinDirection::out);
     csGpioPin.Set();
-    writeProtectionGpioPin.Direction(hal::PinDirection::out);
+    writeProtectionGpioPin.SetDirection(hal::PinDirection::out);
     writeProtectionGpioPin.Set();
     auto const baudRate = 48'000'000;
     Initialize(&flashSpi, baudRate);

--- a/Sts1CobcSw/Periphery/Fram.cpp
+++ b/Sts1CobcSw/Periphery/Fram.cpp
@@ -47,7 +47,7 @@ auto SetWriteEnableLatch() -> void;
 
 auto Initialize() -> void
 {
-    csGpioPin.Direction(hal::PinDirection::out);
+    csGpioPin.SetDirection(hal::PinDirection::out);
     csGpioPin.Set();
 
     auto const baudRate = 6'000'000;

--- a/Sts1CobcSw/Periphery/Rf.cpp
+++ b/Sts1CobcSw/Periphery/Rf.cpp
@@ -164,21 +164,21 @@ auto SetTxType(TxType txType) -> void
 
 auto InitializeGpiosAndSpi() -> void
 {
-    csGpioPin.Direction(hal::PinDirection::out);
+    csGpioPin.SetDirection(hal::PinDirection::out);
 #if HW_VERSION >= 30
-    csGpioPin.OutputType(hal::PinOutputType::openDrain);
+    csGpioPin.SetOutputType(hal::PinOutputType::openDrain);
 #else
-    csGpioPin.OutputType(hal::PinOutputType::pushPull);
+    csGpioPin.SetOutputType(hal::PinOutputType::pushPull);
 #endif
     csGpioPin.Set();
-    nirqGpioPin.Direction(hal::PinDirection::in);
-    sdnGpioPin.Direction(hal::PinDirection::out);
+    nirqGpioPin.SetDirection(hal::PinDirection::in);
+    sdnGpioPin.SetDirection(hal::PinDirection::out);
     sdnGpioPin.Set();
-    gpio0GpioPin.Direction(hal::PinDirection::out);
+    gpio0GpioPin.SetDirection(hal::PinDirection::out);
     gpio0GpioPin.Reset();
-    paEnablePin.Direction(hal::PinDirection::out);
+    paEnablePin.SetDirection(hal::PinDirection::out);
     paEnablePin.Reset();
-    watchdogResetGpioPin.Direction(hal::PinDirection::out);
+    watchdogResetGpioPin.SetDirection(hal::PinDirection::out);
     // The watchdog must be reset at least once to enable the RF module
     watchdogResetGpioPin.Reset();
     SuspendFor(watchDogResetPinDelay);

--- a/Tests/HardwareSetup/HardwareSetupThread.cpp
+++ b/Tests/HardwareSetup/HardwareSetupThread.cpp
@@ -24,7 +24,7 @@ private:
     {
         InitializeRfLatchupDisablePins();
 #ifdef USE_WATCHDOG
-        watchdogClearGpio.Direction(hal::PinDirection::out);
+        watchdogClearGpio.SetDirection(hal::PinDirection::out);
 #endif
     }
 

--- a/Tests/HardwareSetup/RfLatchupProtection.cpp
+++ b/Tests/HardwareSetup/RfLatchupProtection.cpp
@@ -26,11 +26,11 @@ auto InitializeRfLatchupDisablePins() -> void
 {
 #ifndef __linux__
     #if HW_VERSION >= 27 and HW_VERSION < 30
-    rfLatchupDisableGpioPin.Direction(hal::PinDirection::out);
+    rfLatchupDisableGpioPin.SetDirection(hal::PinDirection::out);
     #endif
     #if HW_VERSION >= 30
-    rfLatchupDisableGpioPin1.Direction(hal::PinDirection::out);
-    rfLatchupDisableGpioPin2.Direction(hal::PinDirection::out);
+    rfLatchupDisableGpioPin1.SetDirection(hal::PinDirection::out);
+    rfLatchupDisableGpioPin2.SetDirection(hal::PinDirection::out);
     #endif
 #endif
 }

--- a/Tests/ManualTests/CMakeLists.txt
+++ b/Tests/ManualTests/CMakeLists.txt
@@ -35,7 +35,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL Generic)
 
     add_test_program(Gpio)
     target_link_libraries(
-        Sts1CobcSwTests_Gpio PRIVATE rodos::rodos Sts1CobcSw_Hal Sts1CobcSwTests::HardwareSetup
+        Sts1CobcSwTests_Gpio PRIVATE rodos::rodos Sts1CobcSw_Hal Sts1CobcSw_RodosTime
+                                     Sts1CobcSw_Vocabulary Sts1CobcSwTests::HardwareSetup
     )
 
     add_test_program(MaxPower)

--- a/Tests/ManualTests/DeviceIds.test.cpp
+++ b/Tests/ManualTests/DeviceIds.test.cpp
@@ -41,7 +41,7 @@ public:
 private:
     void init() override
     {
-        led1GpioPin.Direction(hal::PinDirection::out);
+        led1GpioPin.SetDirection(hal::PinDirection::out);
         led1GpioPin.Reset();
     }
 

--- a/Tests/ManualTests/Gpio.test.cpp
+++ b/Tests/ManualTests/Gpio.test.cpp
@@ -1,5 +1,7 @@
 #include <Sts1CobcSw/Hal/GpioPin.hpp>
 #include <Sts1CobcSw/Hal/IoNames.hpp>
+#include <Sts1CobcSw/RodosTime/RodosTime.hpp>
+#include <Sts1CobcSw/Vocabulary/Time.hpp>
 
 #include <rodos_no_using_namespace.h>
 
@@ -8,18 +10,26 @@
 
 namespace sts1cobcsw
 {
-// pa2, pa3 are automatically tested by printing to UCI UART (PRINTF)
-// TODO: Find out which pins we can safely use here. The problem is that some pins cause a short and
-// therefore a reset of the COBC when used in this test. The LED pin has to work for this test
-// though.
-auto pinsToTest = std::to_array<hal::GpioPin>({hal::led1Pin, hal::led2Pin});
+constexpr auto ledBlinkThreadPriority = 100;
+constexpr auto interruptTestPriority = 200;
+
+auto nInterrupts = 0;
+auto ledPins = std::to_array<hal::GpioPin>({hal::led1Pin, hal::led2Pin});
+auto uciUartRxGpioPin = hal::GpioPin(hal::uciUartRxPin);
 
 
-class GpioTest : public RODOS::StaticThread<>
+class LedBlinkThread : public RODOS::StaticThread<>
 {
+public:
+    LedBlinkThread() : StaticThread("LedBlinkThread", ledBlinkThreadPriority)
+    {
+    }
+
+
+private:
     void init() override
     {
-        for(auto & pin : pinsToTest)
+        for(auto & pin : ledPins)
         {
             pin.Direction(hal::PinDirection::out);
         }
@@ -31,7 +41,7 @@ class GpioTest : public RODOS::StaticThread<>
         auto toggle = true;
         TIME_LOOP(0, 1000 * RODOS::MILLISECONDS)
         {
-            for(auto & pin : pinsToTest)
+            for(auto & pin : ledPins)
             {
                 toggle ? pin.Set() : pin.Reset();
                 RODOS::PRINTF("Pin was %s and reads %s\n",
@@ -41,5 +51,47 @@ class GpioTest : public RODOS::StaticThread<>
             toggle = not toggle;
         }
     }
-} gpioTest;
+} ledBlinkThread;
+
+
+class InterruptTest : public RODOS::StaticThread<>
+{
+public:
+    InterruptTest() : StaticThread("InterruptTest", interruptTestPriority)
+    {
+    }
+
+
+private:
+    void init() override
+    {
+        uciUartRxGpioPin.Direction(hal::PinDirection::in);
+        uciUartRxGpioPin.SetInterruptSensitivity(hal::InterruptSensitivity::fallingEdge);
+    }
+
+
+    void run() override
+    {
+        static constexpr auto timeout = 5 * s;
+        RODOS::PRINTF("\n");
+        while(true)
+        {
+            RODOS::PRINTF("Waiting %i s for falling edge interrupts on UCI UART RX pin\n\n",
+                          static_cast<int>(timeout / s));
+            nInterrupts = 0;
+            uciUartRxGpioPin.ResetInterruptStatus();
+            uciUartRxGpioPin.SetInterruptHandler([]() { nInterrupts++; });
+            uciUartRxGpioPin.EnableInterrupts();
+            auto result = uciUartRxGpioPin.SuspendUntilInterrupt(timeout);
+            if(not result.has_error())
+            {
+                sts1cobcsw::SuspendFor(1 * ms);
+            }
+            uciUartRxGpioPin.DisableInterrupts();
+            uciUartRxGpioPin.SetInterruptHandler(nullptr);
+            RODOS::PRINTF("\n");
+            RODOS::PRINTF("%i interrupts occurred\n", nInterrupts);
+        }
+    }
+} interruptTest;
 }

--- a/Tests/ManualTests/Gpio.test.cpp
+++ b/Tests/ManualTests/Gpio.test.cpp
@@ -31,7 +31,7 @@ private:
     {
         for(auto & pin : ledPins)
         {
-            pin.Direction(hal::PinDirection::out);
+            pin.SetDirection(hal::PinDirection::out);
         }
     }
 
@@ -65,7 +65,7 @@ public:
 private:
     void init() override
     {
-        uciUartRxGpioPin.Direction(hal::PinDirection::in);
+        uciUartRxGpioPin.SetDirection(hal::PinDirection::in);
         uciUartRxGpioPin.SetInterruptSensitivity(hal::InterruptSensitivity::fallingEdge);
     }
 

--- a/Tests/ManualTests/MaxPower.test.cpp
+++ b/Tests/ManualTests/MaxPower.test.cpp
@@ -45,8 +45,8 @@ public:
 private:
     void init() override
     {
-        led1GpioPin.Direction(hal::PinDirection::out);
-        led2GpioPin.Direction(hal::PinDirection::out);
+        led1GpioPin.SetDirection(hal::PinDirection::out);
+        led2GpioPin.SetDirection(hal::PinDirection::out);
     }
 
 

--- a/Tests/ManualTests/Watchdog.test.cpp
+++ b/Tests/ManualTests/Watchdog.test.cpp
@@ -17,7 +17,7 @@ class WatchdogTest : public RODOS::StaticThread<>
 {
     void init() override
     {
-        led1Gpio.Direction(hal::PinDirection::out);
+        led1Gpio.SetDirection(hal::PinDirection::out);
     }
 
 


### PR DESCRIPTION
I added the following member functions to the `GPIO` class.

- `SetInterruptSensitivity()`
- `Enable/DisableInterrupts()`
- `ResetInterruptStatus()`
- `SuspendUntilInterrupt()`
- `SetInterruptHandler()`
- `InterruptOccurred()`

I also renamed `Direction()` and `OutputType()` to `SetDirection()` and `SetOutputType()`.

Fixes #349 