### PR TITLE
Add fallback mechanism for EPS

### DIFF
--- a/Sts1CobcSw/CobcSoftware/FramEpsStartupTestThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/FramEpsStartupTestThread.cpp
@@ -52,9 +52,17 @@ private:
             DEBUG_PRINT(" failed to read correct FRAM device ID");
             fram::framIsWorking.Store(false);
         }
-        eps::InitializeAdcs();
-        (void)eps::ReadAdcs();
         persistentVariables.template Store<"epsIsWorking">(true);
+        eps::InitializeAdcs();
+        auto adcData = eps::ReadAdcs();
+        if(adcData == eps::AdcData{})
+        {
+            persistentVariables.template Store<"epsIsWorking">(false);
+        }
+        else
+        {
+            persistentVariables.template Store<"epsIsWorking">(true);
+        }
         ResumeSpiStartupTestAndSupervisorThread();
         SuspendUntil(endOfTime);
     }

--- a/Sts1CobcSw/Sensors/CMakeLists.txt
+++ b/Sts1CobcSw/Sensors/CMakeLists.txt
@@ -2,8 +2,14 @@ target_link_libraries(Sts1CobcSw_Sensors PUBLIC Sts1CobcSw_Serial)
 if(CMAKE_SYSTEM_NAME STREQUAL Generic)
     target_sources(Sts1CobcSw_Sensors PRIVATE Eps.cpp TemperatureSensor.cpp)
     target_link_libraries(
-        Sts1CobcSw_Sensors PRIVATE rodos::rodos strong_type::strong_type Sts1CobcSw_Hal
-                                   Sts1CobcSw_RodosTime Sts1CobcSw_Utility Sts1CobcSw_Vocabulary
+        Sts1CobcSw_Sensors
+        PRIVATE rodos::rodos
+                strong_type::strong_type
+                Sts1CobcSw_FramSections
+                Sts1CobcSw_Hal
+                Sts1CobcSw_RodosTime
+                Sts1CobcSw_Utility
+                Sts1CobcSw_Vocabulary
     )
 else()
     target_sources(Sts1CobcSw_Sensors PRIVATE EpsStubs.cpp TemperatureSensorStubs.cpp)

--- a/Sts1CobcSw/Sensors/Eps.cpp
+++ b/Sts1CobcSw/Sensors/Eps.cpp
@@ -1,3 +1,5 @@
+#include <Sts1CobcSw/FramSections/FramLayout.hpp>
+#include <Sts1CobcSw/FramSections/PersistentVariables.hpp>
 #include <Sts1CobcSw/Hal/GpioPin.hpp>
 #include <Sts1CobcSw/Hal/IoNames.hpp>
 #include <Sts1CobcSw/Hal/Spi.hpp>
@@ -116,6 +118,10 @@ auto ResetAdc(hal::GpioPin * adcCsPin, ResetType resetType) -> void;
 
 auto InitializeAdcs() -> void
 {
+    if(not persistentVariables.template Load<"epsIsWorking">())
+    {
+        return;
+    }
     adc4CsGpioPin.SetDirection(hal::PinDirection::out);
     adc4CsGpioPin.Set();
     adc5CsGpioPin.SetDirection(hal::PinDirection::out);
@@ -140,6 +146,10 @@ auto InitializeAdcs() -> void
 
 auto ReadAdcs() -> AdcData
 {
+    if(not persistentVariables.template Load<"epsIsWorking">())
+    {
+        return AdcData{};
+    }
     auto adcData = AdcData{};
     adcData.adc4 = ReadAdc(&adc4CsGpioPin);
     auto adc5Data = ReadAdc(&adc5CsGpioPin);
@@ -154,6 +164,10 @@ auto ReadAdcs() -> AdcData
 
 auto ResetAdcRegisters() -> void
 {
+    if(not persistentVariables.template Load<"epsIsWorking">())
+    {
+        return;
+    }
     ResetAdc(&adc4CsGpioPin, ResetType::registers);
     ResetAdc(&adc5CsGpioPin, ResetType::registers);
     ResetAdc(&adc6CsGpioPin, ResetType::registers);
@@ -162,6 +176,10 @@ auto ResetAdcRegisters() -> void
 
 auto ClearAdcFifos() -> void
 {
+    if(not persistentVariables.template Load<"epsIsWorking">())
+    {
+        return;
+    }
     ResetAdc(&adc4CsGpioPin, ResetType::fifo);
     ResetAdc(&adc5CsGpioPin, ResetType::fifo);
     ResetAdc(&adc6CsGpioPin, ResetType::fifo);

--- a/Tests/ManualTests/CMakeLists.txt
+++ b/Tests/ManualTests/CMakeLists.txt
@@ -30,8 +30,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL Generic)
 
     add_test_program(Eps)
     target_link_libraries(
-        Sts1CobcSwTests_Eps PRIVATE rodos::rodos Sts1CobcSw_Sensors Sts1CobcSw_Serial
-                                    Sts1CobcSwTests::HardwareSetup
+        Sts1CobcSwTests_Eps PRIVATE rodos::rodos Sts1CobcSw_FramSections Sts1CobcSw_Sensors
+                                    Sts1CobcSw_Serial Sts1CobcSwTests::HardwareSetup
     )
 
     add_test_program(Gpio)

--- a/Tests/ManualTests/Eps.test.cpp
+++ b/Tests/ManualTests/Eps.test.cpp
@@ -1,3 +1,5 @@
+#include <Sts1CobcSw/FramSections/FramLayout.hpp>
+#include <Sts1CobcSw/FramSections/PersistentVariables.hpp>
 #include <Sts1CobcSw/Sensors/Eps.hpp>
 #include <Sts1CobcSw/Serial/Serial.hpp>
 
@@ -30,6 +32,7 @@ private:
         PRINTF("\nEPS test\n\n");
 
         PRINTF("\n");
+        persistentVariables.template Store<"epsIsWorking">(true);
         eps::InitializeAdcs();
         PRINTF("EPS ADCs initialized\n");
 


### PR DESCRIPTION
### Description

* Modify `ReadAdc` function to return an empty `AdcData` struct if EPS is not working.
* Modify the `FramEpsStartupTestThread` to initialize `epsIsWorking` to `true` before attempting to call `eps::ReadAdc()`.
* Update the CMakeLists file of EPS manual test to link against `Sts1CobcSw_Fram`.

Fixes #295