### PR TITLE
Implement the TC Space Data Link Protocol

### DIFF
--- a/Sts1CobcSw/CobcSoftware/TelemetryThread.cpp
+++ b/Sts1CobcSw/CobcSoftware/TelemetryThread.cpp
@@ -113,6 +113,7 @@ auto CollectTelemetryData() -> TelemetryRecord
         .nUncorrectableUplinkErrors = persistentVariables.Load<"nUncorrectableUplinkErrors">(),
         .nGoodTransferFrames = persistentVariables.Load<"nGoodTransferFrames">(),
         .nBadTransferFrames = persistentVariables.Load<"nBadTransferFrames">(),
+        .lastFrameSequenceNumber = persistentVariables.Load<"lastFrameSequenceNumber">(),
         .lastTelecommandId = persistentVariables.Load<"lastTelecommandId">()};
 }
 }

--- a/Sts1CobcSw/FramSections/FramLayout.hpp
+++ b/Sts1CobcSw/FramSections/FramLayout.hpp
@@ -58,6 +58,7 @@ inline constexpr auto persistentVariables =
                         PersistentVariableInfo<"nUncorrectableUplinkErrors", std::uint16_t>,
                         PersistentVariableInfo<"nGoodTransferFrames", std::uint16_t>,
                         PersistentVariableInfo<"nBadTransferFrames", std::uint16_t>,
+                        PersistentVariableInfo<"lastFrameSequenceNumber", std::uint8_t>,
                         PersistentVariableInfo<"lastTelecommandId", std::uint16_t>,
                         PersistentVariableInfo<"lastTelecommandIdWasInvalid", bool>,
                         PersistentVariableInfo<"lastTelecommandArgumentsWereInvalid", bool>>{};

--- a/Sts1CobcSw/Outcome/Outcome.hpp
+++ b/Sts1CobcSw/Outcome/Outcome.hpp
@@ -51,11 +51,16 @@ enum class ErrorCode
     full,
     empty,
     // RF protocols
+    // TODO: Rework the EDU and RF protocol errors once they are fully implemented. Since we send
+    // down the error code with the NACK report, we benefit from fine-grained error codes.
     invalidValue,
     bufferTooSmall,
-    invalidSpacePacket,  // TODO: Maybe use a more general invalidHeader or invalidPdu
-    // TODO: Rework the EDU and RF protocol errors into a smaller set of coherent codes that can be
-    // used for both
+    invalidTransferFrame,
+    invalidSpacecraftId,
+    invalidVcid,
+    invalidFrameLength,
+    invalidSpacePacket,
+    invalidApid,
     invalidPayload,
     // Firmware
     misaligned,

--- a/Sts1CobcSw/RfProtocols/CMakeLists.txt
+++ b/Sts1CobcSw/RfProtocols/CMakeLists.txt
@@ -1,4 +1,6 @@
-target_sources(Sts1CobcSw_RfProtocols PRIVATE SpacePacket.cpp TmTransferFrame.cpp)
+target_sources(
+    Sts1CobcSw_RfProtocols PRIVATE SpacePacket.cpp TcTransferFrame.cpp TmTransferFrame.cpp
+)
 target_link_libraries(
     Sts1CobcSw_RfProtocols PUBLIC etl::etl rodos::without_main_on_linux Sts1CobcSw_Outcome
                                   Sts1CobcSw_Serial

--- a/Sts1CobcSw/RfProtocols/Configuration.hpp
+++ b/Sts1CobcSw/RfProtocols/Configuration.hpp
@@ -59,13 +59,6 @@ inline constexpr auto cfdpVcid = Make<Vcid, 0b101>();
 
 // --- Space Packet Protocol ---
 
-struct PacketType  // I use a struct instead of a namespace because I don't like "packettype"
-{
-    static constexpr auto telemetry = UInt<1>(0);
-    static constexpr auto telecommand = UInt<1>(1);
-};
-
-
 inline constexpr auto packetVersionNumber = UInt<3>(0);
 inline constexpr auto maxPacketLength = tm::transferFrameDataLength;
 inline constexpr auto packetPrimaryHeaderLength = 6U;

--- a/Sts1CobcSw/RfProtocols/Configuration.hpp
+++ b/Sts1CobcSw/RfProtocols/Configuration.hpp
@@ -50,11 +50,11 @@ inline constexpr auto transferFrameDataLength =
 }
 
 using SpacecraftId = Id<UInt<10>, 0x123>;  // NOLINT(*magic-numbers)
-inline constexpr auto spacecraftId = SpacecraftId::Make<0x123>();
+inline constexpr auto spacecraftId = Make<SpacecraftId, 0x123>();
 
 using Vcid = Id<UInt<3>, 0b011, 0b101>;  // NOLINT(*magic-numbers)
-inline constexpr auto pusVcid = Vcid::Make<0b011>();
-inline constexpr auto cfdpVcid = Vcid::Make<0b101>();
+inline constexpr auto pusVcid = Make<Vcid, 0b011>();
+inline constexpr auto cfdpVcid = Make<Vcid, 0b101>();
 
 
 // --- Space Packet Protocol ---
@@ -71,10 +71,9 @@ inline constexpr auto maxPacketLength = tm::transferFrameDataLength;
 inline constexpr auto packetPrimaryHeaderLength = 6U;
 inline constexpr auto maxPacketDataLength = maxPacketLength - packetPrimaryHeaderLength;
 
-using Apid = Id<UInt<11>, 0, 0b000'1100'1100, 0x7FF>;  // NOLINT(*magic-numbers)
-inline constexpr auto invalidApid = Apid::Make<0>();
-inline constexpr auto normalApid = Apid::Make<0b000'1100'1100>();
-inline constexpr auto idlePacketApid = Apid::Make<0x7FF>();
+using Apid = Id<UInt<11>, 0b000'1100'1100, 0x7FF>;  // NOLINT(*magic-numbers)
+inline constexpr auto normalApid = Make<Apid, 0b000'1100'1100>();
+inline constexpr auto idlePacketApid = Make<Apid, 0x7FF>();
 
 inline constexpr auto idleData = 0x55_b;
 }

--- a/Sts1CobcSw/RfProtocols/Configuration.hpp
+++ b/Sts1CobcSw/RfProtocols/Configuration.hpp
@@ -45,8 +45,11 @@ namespace tc
 inline constexpr auto transferFrameVersionNumber = UInt<2>(0);
 inline constexpr auto transferFrameLength = ecc::messageLength;
 inline constexpr auto transferFramePrimaryHeaderLength = 5;
-inline constexpr auto transferFrameDataLength =
-    transferFrameLength - transferFramePrimaryHeaderLength;
+inline constexpr auto securityHeaderLength = 4;   // TODO: What's the right number?
+inline constexpr auto securityTrailerLength = 8;  // TODO: What's the right number?
+inline constexpr auto transferFrameDataLength = transferFrameLength
+                                              - transferFramePrimaryHeaderLength
+                                              - securityHeaderLength - securityTrailerLength;
 }
 
 using SpacecraftId = Id<UInt<10>, 0x123>;  // NOLINT(*magic-numbers)

--- a/Sts1CobcSw/RfProtocols/Id.hpp
+++ b/Sts1CobcSw/RfProtocols/Id.hpp
@@ -57,9 +57,9 @@ template<AnId Id, typename Id::ValueType t>
 [[nodiscard]] constexpr auto Make() -> Id;
 
 template<std::endian endianness, AnId Id>
-auto SerializeTo(void * destination, Id const & id) -> void *;
+[[nodiscard]] auto SerializeTo(void * destination, Id const & id) -> void *;
 template<std::endian endianness, AnId Id>
-auto DeserializeFrom(void const * source, Id * id) -> void const *;
+[[nodiscard]] auto DeserializeFrom(void const * source, Id * id) -> void const *;
 }
 
 

--- a/Sts1CobcSw/RfProtocols/Id.ipp
+++ b/Sts1CobcSw/RfProtocols/Id.ipp
@@ -3,35 +3,15 @@
 
 #include <Sts1CobcSw/RfProtocols/Id.hpp>
 
+#include <algorithm>
+
 
 namespace sts1cobcsw
 {
 template<typename T, T... validIdValues>
     requires(sizeof...(validIdValues) > 0)
-constexpr Id<T, validIdValues...>::Id() : valueIsAnImplementationDetail(validValues[0])
+constexpr Id<T, validIdValues...>::Id(T t) : valueIsAnImplementationDetail(std::move(t))
 {
-}
-
-
-template<typename T, T... validIdValues>
-    requires(sizeof...(validIdValues) > 0)
-template<T t>
-    requires(((t == validIdValues) or ...))
-constexpr auto Id<T, validIdValues...>::Make() -> Id
-{
-    return Id(std::integral_constant<T, t>{});
-}
-
-
-template<typename T, T... validIdValues>
-    requires(sizeof...(validIdValues) > 0)
-constexpr auto Id<T, validIdValues...>::Make(T const & t) -> Result<Id>
-{
-    if(((t == validIdValues) or ...))
-    {
-        return Id(t);
-    }
-    return ErrorCode::invalidValue;
 }
 
 
@@ -43,19 +23,32 @@ constexpr auto Id<T, validIdValues...>::Value() const -> T
 }
 
 
-template<typename T, T... validIdValues>
-    requires(sizeof...(validIdValues) > 0)
-template<T t>
-    requires(((t == validIdValues) or ...))  // NOLINTNEXTLINE(*named-parameter)
-constexpr Id<T, validIdValues...>::Id(std::integral_constant<T, t>)
-    : valueIsAnImplementationDetail(t)
+template<AnId Id>
+[[nodiscard]] constexpr auto IsValid(Id const & id) -> bool
 {
+    return std::find(Id::validValues.begin(), Id::validValues.end(), id.Value())
+        != Id::validValues.end();
 }
 
 
-template<typename T, T... validIdValues>
-    requires(sizeof...(validIdValues) > 0)
-constexpr Id<T, validIdValues...>::Id(T const & t) : valueIsAnImplementationDetail(t)
+template<AnId Id, typename Id::ValueType t>
+    requires(IsValid(Id(t)))
+[[nodiscard]] constexpr auto Make() -> Id
 {
+    return Id(t);
+}
+
+
+template<std::endian endianness, AnId Id>
+auto SerializeTo(void * destination, Id const & id) -> void *
+{
+    return SerializeTo<endianness>(destination, id.Value());
+}
+
+
+template<std::endian endianness, AnId Id>
+auto DeserializeFrom(void const * source, Id * id) -> void const *
+{
+    return DeserializeFrom<endianness>(source, &id->valueIsAnImplementationDetail);
 }
 }

--- a/Sts1CobcSw/RfProtocols/SpacePacket.cpp
+++ b/Sts1CobcSw/RfProtocols/SpacePacket.cpp
@@ -50,7 +50,7 @@ auto ParseAsSpacePacket(std::span<Byte const> buffer) -> Result<SpacePacket>
     (void)DeserializeFrom<std::endian::big>(buffer.data(), &primaryHeader);
     auto packetIsValid = primaryHeader.versionNumber == packetVersionNumber
                      and primaryHeader.packetType == PacketType::telecommand
-                     and primaryHeader.apid != invalidApid and primaryHeader.sequenceFlags == 0b11;
+                     and IsValid(primaryHeader.apid) and primaryHeader.sequenceFlags == 0b11;
     if(not packetIsValid)
     {
         return ErrorCode::invalidSpacePacket;
@@ -96,16 +96,7 @@ auto DeserializeFrom(void const * source, SpacePacketPrimaryHeader * header) -> 
                                          &apidValue,
                                          &header->sequenceFlags,
                                          &header->packetSequenceCount);
-    // This is ugly but I don't know how to do it better
-    auto makeResult = Apid::Make(apidValue);
-    if(makeResult.has_error())
-    {
-        header->apid = invalidApid;
-    }
-    else
-    {
-        header->apid = makeResult.value();
-    }
+    header->apid = Apid(apidValue);
     source = DeserializeFrom<endianness>(source, &header->packetDataLength);
     return source;
 }

--- a/Sts1CobcSw/RfProtocols/SpacePacket.cpp
+++ b/Sts1CobcSw/RfProtocols/SpacePacket.cpp
@@ -1,6 +1,8 @@
 #include <Sts1CobcSw/RfProtocols/IdCounters.hpp>
 #include <Sts1CobcSw/RfProtocols/SpacePacket.hpp>
 
+#include <algorithm>
+
 
 namespace sts1cobcsw
 {
@@ -29,7 +31,7 @@ auto AddSpacePacketTo(etl::ivector<Byte> * dataField,
     dataField->resize(dataField->size() + packetPrimaryHeaderLength);
     auto primaryHeader = SpacePacketPrimaryHeader{
         .versionNumber = packetVersionNumber,
-        .packetType = PacketType::telemetry,
+        .packetType = packettype::telemetry,
         .secondaryHeaderFlag = hasSecondaryHeader ? 1 : 0,
         .apid = apid,
         .sequenceFlags = 0b11,
@@ -49,7 +51,7 @@ auto ParseAsSpacePacket(std::span<Byte const> buffer) -> Result<SpacePacket>
     auto primaryHeader = SpacePacketPrimaryHeader();
     (void)DeserializeFrom<std::endian::big>(buffer.data(), &primaryHeader);
     auto packetIsValid = primaryHeader.versionNumber == packetVersionNumber
-                     and primaryHeader.packetType == PacketType::telecommand
+                     and primaryHeader.packetType == packettype::telecommand
                      and IsValid(primaryHeader.apid) and primaryHeader.sequenceFlags == 0b11;
     if(not packetIsValid)
     {

--- a/Sts1CobcSw/RfProtocols/SpacePacket.hpp
+++ b/Sts1CobcSw/RfProtocols/SpacePacket.hpp
@@ -1,17 +1,31 @@
 #pragma once
 
 
+#include <Sts1CobcSw/Outcome/Outcome.hpp>
 #include <Sts1CobcSw/RfProtocols/Configuration.hpp>
+#include <Sts1CobcSw/RfProtocols/Id.hpp>
 #include <Sts1CobcSw/RfProtocols/Payload.hpp>
 #include <Sts1CobcSw/Serial/Byte.hpp>
 #include <Sts1CobcSw/Serial/Serial.hpp>
 #include <Sts1CobcSw/Serial/UInt.hpp>
 
+#include <etl/vector.h>
+
 #include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <span>
 
 
 namespace sts1cobcsw
 {
+namespace packettype
+{
+constexpr auto telemetry = UInt<1>(0);
+constexpr auto telecommand = UInt<1>(1);
+};
+
+
 // TODO: Consider moving this into SpacePacket
 struct SpacePacketPrimaryHeader
 {

--- a/Sts1CobcSw/RfProtocols/SpacePacket.hpp
+++ b/Sts1CobcSw/RfProtocols/SpacePacket.hpp
@@ -12,6 +12,7 @@
 
 namespace sts1cobcsw
 {
+// TODO: Consider moving this into SpacePacket
 struct SpacePacketPrimaryHeader
 {
     UInt<3> versionNumber = sts1cobcsw::packetVersionNumber;
@@ -34,7 +35,7 @@ struct SpacePacket
 
 
 template<>
-inline constexpr auto serialSize<SpacePacketPrimaryHeader> =
+inline constexpr std::size_t serialSize<SpacePacketPrimaryHeader> =
     totalSerialSize<decltype(SpacePacketPrimaryHeader::versionNumber),
                     decltype(SpacePacketPrimaryHeader::packetType),
                     decltype(SpacePacketPrimaryHeader::secondaryHeaderFlag),

--- a/Sts1CobcSw/RfProtocols/SpacePacket.hpp
+++ b/Sts1CobcSw/RfProtocols/SpacePacket.hpp
@@ -68,7 +68,9 @@ static_assert(serialSize<SpacePacketPrimaryHeader> == packetPrimaryHeaderLength)
 
 
 template<std::endian endianness>
-auto SerializeTo(void * destination, SpacePacketPrimaryHeader const & header) -> void *;
+[[nodiscard]] auto SerializeTo(void * destination, SpacePacketPrimaryHeader const & header)
+    -> void *;
 template<std::endian endianness>
-auto DeserializeFrom(void const * source, SpacePacketPrimaryHeader * header) -> void const *;
+[[nodiscard]] auto DeserializeFrom(void const * source, SpacePacketPrimaryHeader * header)
+    -> void const *;
 }

--- a/Sts1CobcSw/RfProtocols/TcTransferFrame.cpp
+++ b/Sts1CobcSw/RfProtocols/TcTransferFrame.cpp
@@ -1,0 +1,62 @@
+#include <Sts1CobcSw/RfProtocols/TcTransferFrame.hpp>
+
+
+namespace sts1cobcsw::tc
+{
+auto ParseAsTransferFrame(std::span<Byte const, transferFrameLength> buffer)
+    -> Result<TransferFrame>
+{
+    auto frame = TransferFrame{
+        .primaryHeader = {},
+        .dataField = buffer.subspan<transferFramePrimaryHeaderLength + securityHeaderLength,
+                                    transferFrameDataLength>()};
+    (void)DeserializeFrom<std::endian::big>(buffer.data(), &frame.primaryHeader);
+    auto frameIsValid = frame.primaryHeader.versionNumber == transferFrameVersionNumber
+                    and frame.primaryHeader.bypassFlag == 1
+                    and frame.primaryHeader.controlCommandFlag == 0;
+    if(not frameIsValid)
+    {
+        return ErrorCode::invalidTransferFrame;
+    }
+    if(not IsValid(frame.primaryHeader.spacecraftId))
+    {
+        return ErrorCode::invalidSpacecraftId;
+    }
+    if(not(frame.primaryHeader.extraVcidBits == 0 and IsValid(frame.primaryHeader.vcid)))
+    {
+        return ErrorCode::invalidVcid;
+    }
+    if(frame.primaryHeader.frameLength != transferFrameLength - 1)
+    {
+        return ErrorCode::invalidFrameLength;
+    }
+    // TODO: Think about what to do with the frame sequence number
+    return frame;
+}
+
+
+template<std::endian endianness>
+auto DeserializeFrom(void const * source, TransferFrame::PrimaryHeader * header) -> void const *
+{
+    auto spacecraftIdValue = SpacecraftId::ValueType{};
+    auto vcidValue = Vcid::ValueType{};
+    source = sts1cobcsw::DeserializeFrom<endianness>(source,
+                                                     &header->versionNumber,
+                                                     &header->bypassFlag,
+                                                     &header->controlCommandFlag,
+                                                     &header->spare,
+                                                     &spacecraftIdValue,
+                                                     &header->extraVcidBits,
+                                                     &vcidValue,
+                                                     &header->frameLength);
+    header->spacecraftId = SpacecraftId(spacecraftIdValue);
+    header->vcid = Vcid(vcidValue);
+    source = sts1cobcsw::DeserializeFrom<endianness>(source, &header->frameSequenceNumber);
+    return source;
+}
+
+
+template auto DeserializeFrom<std::endian::big>(void const * source,
+                                                TransferFrame::PrimaryHeader * header)
+    -> void const *;
+}

--- a/Sts1CobcSw/RfProtocols/TcTransferFrame.hpp
+++ b/Sts1CobcSw/RfProtocols/TcTransferFrame.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+
+#include <Sts1CobcSw/Outcome/Outcome.hpp>
+#include <Sts1CobcSw/RfProtocols/Configuration.hpp>
+#include <Sts1CobcSw/Serial/Byte.hpp>
+#include <Sts1CobcSw/Serial/Serial.hpp>
+#include <Sts1CobcSw/Serial/UInt.hpp>
+
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+
+namespace sts1cobcsw
+{
+namespace tc
+{
+// TODO: Add security header and trailer
+struct TransferFrame
+{
+    struct PrimaryHeader
+    {
+        UInt<2> versionNumber;
+        UInt<1> bypassFlag;
+        UInt<1> controlCommandFlag;
+        UInt<2> spare;
+        SpacecraftId spacecraftId;
+        UInt<3> extraVcidBits;
+        Vcid vcid;
+        UInt<10> frameLength;  // NOLINT(*magic-numbers)
+        std::uint8_t frameSequenceNumber = 0;
+    };
+
+    PrimaryHeader primaryHeader;
+    std::span<Byte const, transferFrameDataLength> dataField;
+};
+
+
+[[nodiscard]] auto ParseAsTransferFrame(std::span<Byte const, transferFrameLength> buffer)
+    -> Result<TransferFrame>;
+
+template<std::endian endianness>
+[[nodiscard]] auto DeserializeFrom(void const * source, TransferFrame::PrimaryHeader * header)
+    -> void const *;
+}
+
+
+template<>
+inline constexpr std::size_t serialSize<tc::TransferFrame::PrimaryHeader> =
+    totalSerialSize<decltype(tc::TransferFrame::PrimaryHeader::versionNumber),
+                    decltype(tc::TransferFrame::PrimaryHeader::bypassFlag),
+                    decltype(tc::TransferFrame::PrimaryHeader::controlCommandFlag),
+                    decltype(tc::TransferFrame::PrimaryHeader::spare),
+                    decltype(tc::TransferFrame::PrimaryHeader::spacecraftId.Value()),
+                    decltype(tc::TransferFrame::PrimaryHeader::extraVcidBits),
+                    decltype(tc::TransferFrame::PrimaryHeader::vcid.Value()),
+                    decltype(tc::TransferFrame::PrimaryHeader::frameLength)>
+    + totalSerialSize<decltype(tc::TransferFrame::PrimaryHeader::frameSequenceNumber)>;
+static_assert(serialSize<tc::TransferFrame::PrimaryHeader> == tc::transferFramePrimaryHeaderLength);
+}

--- a/Sts1CobcSw/RfProtocols/TmTransferFrame.hpp
+++ b/Sts1CobcSw/RfProtocols/TmTransferFrame.hpp
@@ -62,7 +62,8 @@ private:
 
 
 template<std::endian endianness>
-auto SerializeTo(void * destination, TransferFrame::PrimaryHeader const & header) -> void *;
+[[nodiscard]] [[nodiscard]] auto SerializeTo(void * destination,
+                                             TransferFrame::PrimaryHeader const & header) -> void *;
 }
 
 

--- a/Sts1CobcSw/Telemetry/TelemetryRecord.cpp
+++ b/Sts1CobcSw/Telemetry/TelemetryRecord.cpp
@@ -45,6 +45,7 @@ auto DeserializeFrom(void const * source, TelemetryRecord * data) -> void const 
     source = DeserializeFrom<endianness>(source, &(data->nUncorrectableUplinkErrors));
     source = DeserializeFrom<endianness>(source, &(data->nGoodTransferFrames));
     source = DeserializeFrom<endianness>(source, &(data->nBadTransferFrames));
+    source = DeserializeFrom<endianness>(source, &(data->lastFrameSequenceNumber));
     source = DeserializeFrom<endianness>(source, &(data->lastTelecommandId));
     return source;
 }
@@ -92,6 +93,7 @@ auto SerializeTo(void * destination, TelemetryRecord const & data) -> void *
     destination = SerializeTo<endianness>(destination, data.nUncorrectableUplinkErrors);
     destination = SerializeTo<endianness>(destination, data.nGoodTransferFrames);
     destination = SerializeTo<endianness>(destination, data.nBadTransferFrames);
+    destination = SerializeTo<endianness>(destination, data.lastFrameSequenceNumber);
     destination = SerializeTo<endianness>(destination, data.lastTelecommandId);
     return destination;
 }

--- a/Sts1CobcSw/Telemetry/TelemetryRecord.hpp
+++ b/Sts1CobcSw/Telemetry/TelemetryRecord.hpp
@@ -60,7 +60,9 @@ struct TelemetryRecord
     std::uint16_t nUncorrectableUplinkErrors = 0U;
     std::uint16_t nGoodTransferFrames = 0U;
     std::uint16_t nBadTransferFrames = 0U;
+    // TODO: I think this should be a tc::MessageTypeId
     std::uint16_t lastTelecommandId = 0U;
+    // TODO: Add one of the sequence numbers
 
     friend auto operator==(TelemetryRecord const &, TelemetryRecord const &) -> bool = default;
 };

--- a/Sts1CobcSw/Telemetry/TelemetryRecord.hpp
+++ b/Sts1CobcSw/Telemetry/TelemetryRecord.hpp
@@ -60,9 +60,9 @@ struct TelemetryRecord
     std::uint16_t nUncorrectableUplinkErrors = 0U;
     std::uint16_t nGoodTransferFrames = 0U;
     std::uint16_t nBadTransferFrames = 0U;
+    std::uint8_t lastFrameSequenceNumber = 0U;
     // TODO: I think this should be a tc::MessageTypeId
     std::uint16_t lastTelecommandId = 0U;
-    // TODO: Add one of the sequence numbers
 
     friend auto operator==(TelemetryRecord const &, TelemetryRecord const &) -> bool = default;
 };
@@ -100,6 +100,7 @@ inline constexpr std::size_t serialSize<TelemetryRecord> =
         decltype(TelemetryRecord::nUncorrectableUplinkErrors),
         decltype(TelemetryRecord::nGoodTransferFrames),
         decltype(TelemetryRecord::nBadTransferFrames),
+        decltype(TelemetryRecord::lastFrameSequenceNumber),
         decltype(TelemetryRecord::lastTelecommandId)>;
 
 

--- a/Tests/UnitTests/CMakeLists.txt
+++ b/Tests/UnitTests/CMakeLists.txt
@@ -218,6 +218,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     )
     catch_discover_tests(Sts1CobcSwTests_Subsections)
 
+    add_test_program(TcTransferFrame)
+    target_link_libraries(
+        Sts1CobcSwTests_TcTransferFrame
+        PRIVATE Sts1CobcSw_Outcome Sts1CobcSw_RfProtocols Sts1CobcSw_Serial Sts1CobcSw_Utility
+                Sts1CobcSwTests::CatchRodos Sts1CobcSwTests::Utility
+    )
+    add_test(NAME TcTransferFrame COMMAND Sts1CobcSwTests_TcTransferFrame)
+
     add_test_program(TelemetryRecord)
     target_link_libraries(
         Sts1CobcSwTests_TelemetryRecord

--- a/Tests/UnitTests/Id.test.cpp
+++ b/Tests/UnitTests/Id.test.cpp
@@ -1,73 +1,67 @@
 #include <Tests/CatchRodos/TestMacros.hpp>
 
-#include <Sts1CobcSw/Outcome/Outcome.hpp>
 #include <Sts1CobcSw/RfProtocols/Id.hpp>
 
 #include <algorithm>
 #include <array>
-#include <initializer_list>
 #include <type_traits>
 
 
+using sts1cobcsw::Make;
 using MyId = sts1cobcsw::Id<int, 1, 2, 3, 17>;
 
 
 // This struct allows us to use std::is_invocable_v to test if some calls to MyId::Make() do not
 // compile without actually throwing compiler errors. See Span.test.cpp for an explanation.
-struct CallMyIdMake
+struct CallMakeMyId
 {
     template<int t>
-    auto operator()(std::integral_constant<int, t>) const -> decltype(MyId::Make<t>());
+    auto operator()(std::integral_constant<int, t>) const -> decltype(Make<MyId, t>());
 };
 
 
-// validValues
+// ValueType and validValues
+static_assert(std::is_same_v<MyId::ValueType, int>);
 static_assert(MyId::validValues == std::array{1, 2, 3, 17});
 
+// Construction
+static_assert(std::is_default_constructible_v<MyId>);
+constexpr auto id0 = MyId();
+constexpr auto id1 = MyId{1};
+constexpr auto id5 = MyId(5);
+
+
 // Make<>()
-static constexpr auto id1 = MyId::Make<1>();
-static constexpr auto id2 = MyId::Make<2>();
-static_assert(std::is_invocable_v<CallMyIdMake, std::integral_constant<int, 3>>);
-static_assert(std::is_invocable_v<CallMyIdMake, std::integral_constant<int, 17>>);
-static_assert(not std::is_invocable_v<CallMyIdMake, std::integral_constant<int, -1>>);
-static_assert(not std::is_invocable_v<CallMyIdMake, std::integral_constant<int, 0>>);
-static_assert(not std::is_invocable_v<CallMyIdMake, std::integral_constant<int, 4>>);
-static_assert(not std::is_invocable_v<CallMyIdMake, std::integral_constant<int, 16>>);
-static_assert(not std::is_invocable_v<CallMyIdMake, std::integral_constant<int, 123456>>);
+constexpr auto id2 = Make<MyId, 2>();
+static_assert(std::is_invocable_v<CallMakeMyId, std::integral_constant<int, 3>>);
+static_assert(std::is_invocable_v<CallMakeMyId, std::integral_constant<int, 17>>);
+static_assert(not std::is_invocable_v<CallMakeMyId, std::integral_constant<int, -1>>);
+static_assert(not std::is_invocable_v<CallMakeMyId, std::integral_constant<int, 0>>);
+static_assert(not std::is_invocable_v<CallMakeMyId, std::integral_constant<int, 4>>);
+static_assert(not std::is_invocable_v<CallMakeMyId, std::integral_constant<int, 16>>);
+static_assert(not std::is_invocable_v<CallMakeMyId, std::integral_constant<int, 123456>>);
 
 // operator==()
-static_assert(id1 == MyId::Make<1>());
+static_assert(id1 == Make<MyId, 1>());
 static_assert(id1 != id2);
+static_assert(id1 != id5);
 
 // Value()
+static_assert(id0.Value() == 0);
 static_assert(id1.Value() == 1);
-static_assert(id2.Value() == 2);
-static_assert(MyId::Make<17>().Value() == 17);
+static_assert(id5.Value() == 5);
+static_assert(Make<MyId, 17>().Value() == 17);
 
-// Default constructor
-static_assert(std::is_default_constructible_v<MyId>);
-static_assert(MyId{} == MyId::Make<1>());
-static_assert(MyId{}.Value() == 1);
+// IsValid()
+static_assert(not IsValid(id0));
+static_assert(IsValid(id1));
+static_assert(not IsValid(id5));
 
 
 TEST_CASE("Id")
 {
-    auto makeResult = MyId::Make(1);
-    CHECK(makeResult.has_value());
-    CHECK(makeResult.value() == MyId::Make<1>());
-
-    for(auto i : MyId::validValues)
-    {
-        makeResult = MyId::Make(i);
-        CHECK(makeResult.has_value());
-        auto myId = makeResult.value();
-        CHECK(myId.Value() == i);
-    }
-
-    for(auto i : {-1, 0, 16, 123456})
-    {
-        makeResult = MyId::Make(i);
-        CHECK(makeResult.has_error());
-        CHECK(makeResult.error() == sts1cobcsw::ErrorCode::invalidValue);
-    }
+    auto myId = MyId{};
+    CHECK(not IsValid(myId));
+    myId = MyId(17);
+    CHECK(IsValid(myId));
 }

--- a/Tests/UnitTests/IdCounters.test.cpp
+++ b/Tests/UnitTests/IdCounters.test.cpp
@@ -3,29 +3,42 @@
 #include <Sts1CobcSw/RfProtocols/Id.hpp>
 #include <Sts1CobcSw/RfProtocols/IdCounters.hpp>
 
+#include <cstdint>
 
-using MyId = sts1cobcsw::Id<int, 1, 4, 7>;
+
+using sts1cobcsw::Make;
+
+
+struct MyIdFields
+{
+    std::uint8_t minor = 0;
+    std::uint8_t major = 0;
+
+    friend constexpr auto operator==(MyIdFields const &, MyIdFields const &) -> bool = default;
+};
+
+using MyId = sts1cobcsw::Id<MyIdFields, MyIdFields{0, 1}, MyIdFields{3, 5}, MyIdFields{7, 9}>;
 
 
 auto myIdCounters = sts1cobcsw::IdCounters<int, MyId>{};
 
-constexpr auto id1 = MyId::Make<1>();
-constexpr auto id4 = MyId::Make<4>();
-constexpr auto id7 = MyId::Make<7>();
+constexpr auto id1 = Make<MyId, MyIdFields{0, 1}>();
+constexpr auto id2 = Make<MyId, MyIdFields{3, 5}>();
+constexpr auto id3 = Make<MyId, MyIdFields{7, 9}>();
 
 
 TEST_CASE("IdCounters")
 {
     CHECK(myIdCounters.Get(id1) == 0);
-    CHECK(myIdCounters.Get(id4) == 0);
-    CHECK(myIdCounters.Get(id7) == 0);
+    CHECK(myIdCounters.Get(id2) == 0);
+    CHECK(myIdCounters.Get(id3) == 0);
     for(auto i = 0; i < 10; ++i)
     {
         CHECK(myIdCounters.PostIncrement(id1) == i);
-        CHECK(myIdCounters.PostIncrement(id4) == i);
-        CHECK(myIdCounters.PostIncrement(id7) == i);
+        CHECK(myIdCounters.PostIncrement(id2) == i);
+        CHECK(myIdCounters.PostIncrement(id3) == i);
         CHECK(myIdCounters.Get(id1) == i + 1);
-        CHECK(myIdCounters.Get(id4) == i + 1);
-        CHECK(myIdCounters.Get(id7) == i + 1);
+        CHECK(myIdCounters.Get(id2) == i + 1);
+        CHECK(myIdCounters.Get(id3) == i + 1);
     }
 }

--- a/Tests/UnitTests/SpacePacket.test.cpp
+++ b/Tests/UnitTests/SpacePacket.test.cpp
@@ -135,7 +135,7 @@ TEST_CASE("Parsing Space Packets")
     CHECK(parseResult.has_value());
     auto packet = parseResult.value();
     CHECK(packet.primaryHeader.versionNumber == sts1cobcsw::packetVersionNumber);
-    CHECK(packet.primaryHeader.packetType == sts1cobcsw::PacketType::telecommand);
+    CHECK(packet.primaryHeader.packetType == sts1cobcsw::packettype::telecommand);
     CHECK(packet.primaryHeader.secondaryHeaderFlag == 1);
     CHECK(packet.primaryHeader.apid == sts1cobcsw::normalApid);
     CHECK(packet.primaryHeader.sequenceFlags == 0b11);
@@ -155,7 +155,7 @@ TEST_CASE("Parsing Space Packets")
     CHECK(parseResult.has_value());
     packet = parseResult.value();
     CHECK(packet.primaryHeader.versionNumber == sts1cobcsw::packetVersionNumber);
-    CHECK(packet.primaryHeader.packetType == sts1cobcsw::PacketType::telecommand);
+    CHECK(packet.primaryHeader.packetType == sts1cobcsw::packettype::telecommand);
     CHECK(packet.primaryHeader.secondaryHeaderFlag == 0);
     CHECK(packet.primaryHeader.apid == sts1cobcsw::idlePacketApid);
     CHECK(packet.primaryHeader.sequenceFlags == 0b11);

--- a/Tests/UnitTests/TcTransferFrame.test.cpp
+++ b/Tests/UnitTests/TcTransferFrame.test.cpp
@@ -1,0 +1,73 @@
+#include <Tests/CatchRodos/TestMacros.hpp>
+#include <Tests/Utility/Stringification.hpp>  // IWYU pragma: keep
+
+#include <Sts1CobcSw/Outcome/Outcome.hpp>
+#include <Sts1CobcSw/RfProtocols/Configuration.hpp>
+#include <Sts1CobcSw/RfProtocols/Id.hpp>
+#include <Sts1CobcSw/RfProtocols/TcTransferFrame.hpp>
+#include <Sts1CobcSw/Serial/Byte.hpp>
+#include <Sts1CobcSw/Utility/Span.hpp>
+
+#include <array>
+#include <span>
+
+
+using sts1cobcsw::Byte;
+using sts1cobcsw::ErrorCode;
+using sts1cobcsw::Span;
+using sts1cobcsw::operator""_b;
+
+
+TEST_CASE("Parsing TC Transfer Frames")
+{
+    auto buffer = std::array<Byte, sts1cobcsw::tc::transferFrameLength>{};
+    buffer[0] = 0b0010'0001_b;  // Version number, bypass flag, control command flag, spare
+    buffer[1] = 0x23_b;         // Spacecraft ID
+    buffer[2] = 0b0000'1100_b;  // VCID, frame length
+    buffer[3] = 222_b;          // Frame length
+    buffer[4] = 13_b;           // Frame sequence number
+    // Data field
+    buffer[5 + sts1cobcsw::tc::securityHeaderLength] = 0xFF_b;
+    buffer[6 + sts1cobcsw::tc::securityHeaderLength] = 0xEE_b;
+    auto parseResult = sts1cobcsw::tc::ParseAsTransferFrame(Span(buffer));
+    CHECK(parseResult.has_value());
+    auto & frame = parseResult.value();
+    CHECK(frame.primaryHeader.vcid == sts1cobcsw::pusVcid);
+    CHECK(frame.primaryHeader.frameSequenceNumber == 13);
+    CHECK(frame.dataField[0] == 0xFF_b);
+    CHECK(frame.dataField[1] == 0xEE_b);
+    CHECK(frame.dataField[2] == 0x00_b);
+
+    buffer[0] = 0b1010'0001_b;  // Wrong version number
+    parseResult = sts1cobcsw::tc::ParseAsTransferFrame(Span(buffer));
+    CHECK(parseResult.has_error());
+    CHECK(parseResult.error() == sts1cobcsw::ErrorCode::invalidTransferFrame);
+
+    buffer[0] = 0b0000'0001_b;  // Wrong bypass flag
+    parseResult = sts1cobcsw::tc::ParseAsTransferFrame(Span(buffer));
+    CHECK(parseResult.has_error());
+    CHECK(parseResult.error() == sts1cobcsw::ErrorCode::invalidTransferFrame);
+
+    buffer[0] = 0b0011'1001_b;  // Wrong control command flag
+    parseResult = sts1cobcsw::tc::ParseAsTransferFrame(Span(buffer));
+    CHECK(parseResult.has_error());
+    CHECK(parseResult.error() == sts1cobcsw::ErrorCode::invalidTransferFrame);
+
+    buffer[0] = 0b0010'0001_b;  // Correct version number, bypass flag, control command flag
+    buffer[1] = 0x17_b;         // Wrong spacecraft ID
+    parseResult = sts1cobcsw::tc::ParseAsTransferFrame(Span(buffer));
+    CHECK(parseResult.has_error());
+    CHECK(parseResult.error() == sts1cobcsw::ErrorCode::invalidSpacecraftId);
+
+    buffer[1] = 0x23_b;         // Correct spacecraft ID
+    buffer[2] = 0b0001'1100_b;  // Wrong VCID
+    parseResult = sts1cobcsw::tc::ParseAsTransferFrame(Span(buffer));
+    CHECK(parseResult.has_error());
+    CHECK(parseResult.error() == sts1cobcsw::ErrorCode::invalidVcid);
+
+    buffer[2] = 0b0000'1100_b;  // Correct VCID
+    buffer[3] = 255_b;          // Frame length too large
+    parseResult = sts1cobcsw::tc::ParseAsTransferFrame(Span(buffer));
+    CHECK(parseResult.has_error());
+    CHECK(parseResult.error() == sts1cobcsw::ErrorCode::invalidFrameLength);
+}

--- a/Tests/UnitTests/TelemetryRecord.test.cpp
+++ b/Tests/UnitTests/TelemetryRecord.test.cpp
@@ -63,7 +63,8 @@ TEST_CASE("(De-)Serialization of TelemetryRecord")
             .nUncorrectableUplinkErrors = 56U,
             .nGoodTransferFrames = 57U,
             .nBadTransferFrames = 58U,
-            .lastTelecommandId = 59U
+            .lastFrameSequenceNumber = 59U,
+            .lastTelecommandId = 60U,
         };
         auto serializedRecord = Serialize(originalRecord);
         auto deserializedRecord = Deserialize<TelemetryRecord>(serializedRecord);

--- a/Tests/UnitTests/UInt.test.cpp
+++ b/Tests/UnitTests/UInt.test.cpp
@@ -11,9 +11,6 @@ using sts1cobcsw::AUInt;
 using sts1cobcsw::SmallestUnsignedType;
 using sts1cobcsw::UInt;
 
-template<auto value>
-using Constant = std::integral_constant<decltype(value), value>;
-
 
 // This struct allows us to use std::is_invocable_v to test if constructing a UInt<> does not
 // compile without actually throwing compiler errors. See Span.test.cpp for an explanation.

--- a/Tests/Utility/Stringification.cpp
+++ b/Tests/Utility/Stringification.cpp
@@ -98,8 +98,23 @@ auto Append(ValueString * string, ErrorCode const & value) -> void
         case ErrorCode::bufferTooSmall:
             Append(string, "ErrorCode::bufferTooSmall");
             break;
+        case ErrorCode::invalidTransferFrame:
+            Append(string, "ErrorCode::invalidTransferFrame");
+            break;
+        case ErrorCode::invalidSpacecraftId:
+            Append(string, "ErrorCode::invalidSpacecraftId");
+            break;
+        case ErrorCode::invalidVcid:
+            Append(string, "ErrorCode::invalidVcid");
+            break;
+        case ErrorCode::invalidFrameLength:
+            Append(string, "ErrorCode::invalidFrameLength");
+            break;
         case ErrorCode::invalidSpacePacket:
             Append(string, "ErrorCode::invalidSpacePacket");
+            break;
+        case ErrorCode::invalidApid:
+            Append(string, "ErrorCode::invalidApid");
             break;
         case ErrorCode::invalidPayload:
             Append(string, "ErrorCode::invalidPayload");

--- a/iwyu.imp
+++ b/iwyu.imp
@@ -114,6 +114,8 @@
   { include: ["\"Sts1CobcSw/RfProtocols/Id.hpp\"",                                 "public", "<Sts1CobcSw/RfProtocols/Id.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/RfProtocols/IdCounters.hpp\"",                         "public", "<Sts1CobcSw/RfProtocols/IdCounters.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/RfProtocols/Payload.hpp\"",                            "public", "<Sts1CobcSw/RfProtocols/Payload.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/RfProtocols/SpacePacket.hpp\"",                        "public", "<Sts1CobcSw/RfProtocols/SpacePacket.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/RfProtocols/TcTransferFrame.hpp\"",                    "public", "<Sts1CobcSw/RfProtocols/TcTransferFrame.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/RfProtocols/TmTransferFrame.hpp\"",                    "public", "<Sts1CobcSw/RfProtocols/TmTransferFrame.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Hal/Spis.hpp\"",                                       "public", "<Sts1CobcSw/Hal/Spis.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Serial/Byte.hpp\"",                                    "public", "<Sts1CobcSw/Serial/Byte.hpp>", "public"] },


### PR DESCRIPTION
Fixes #378 

Also, reworks `Id<>` and adds the last frame sequence number to `TelemetryRecord` and as a persistent variable.