### PR TITLE
Fix EPS ADCs, some stack sizes, and firmware startup

### DIFF
--- a/CMakeDeveloperPresets.json
+++ b/CMakeDeveloperPresets.json
@@ -28,7 +28,10 @@
     {
       "name": "dev-linux-x86-fast",
       "inherits": "dev-common",
-      "toolchainFile": "/linux-x86.cmake"
+      "toolchainFile": "/linux-x86.cmake",
+      "cacheVariables": {
+        "ENABLE_DEBUG_PRINT_STACK_USAGE": "OFF"
+      }
     },
     {
       "name": "dev-linux-x86",
@@ -46,7 +49,8 @@
         "HSE_VALUE": "12000000",
         "HW_VERSION": "30",
         "REDIRECT_RF_OVER_UCI": "OFF",
-        "DISABLE_CHANNEL_CODING": "OFF"
+        "DISABLE_CHANNEL_CODING": "OFF",
+        "ENABLE_DEBUG_PRINT_STACK_USAGE": "OFF"
       }
     },
     {

--- a/Sts1CobcSw/Edu/EduMock.cpp
+++ b/Sts1CobcSw/Edu/EduMock.cpp
@@ -14,10 +14,7 @@
 namespace sts1cobcsw::edu
 {
 auto Initialize() -> void
-{
-    DEBUG_PRINT_REAL_TIME();
-    DEBUG_PRINT("Call to Initialize()\n");
-}
+{}
 
 
 auto TurnOn() -> void

--- a/Sts1CobcSw/Firmware/CMakeLists.txt
+++ b/Sts1CobcSw/Firmware/CMakeLists.txt
@@ -11,7 +11,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Generic)
                 FramEpsStartupTestThread.cpp
                 RfCommunicationThread.cpp
                 RfStartupTestThread.cpp
-                SpiStartupTestAndSupervisorThread.cpp
+                StartupAndSpiSupervisorThread.cpp
                 TelemetryThread.cpp
                 TopicsAndSubscribers.cpp
     )

--- a/Sts1CobcSw/Firmware/EduCommunicationErrorThread.cpp
+++ b/Sts1CobcSw/Firmware/EduCommunicationErrorThread.cpp
@@ -1,7 +1,7 @@
 #include <Sts1CobcSw/Firmware/EduCommunicationErrorThread.hpp>
 
 #include <Sts1CobcSw/Edu/Edu.hpp>
-#include <Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>
+#include <Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>
 #include <Sts1CobcSw/Firmware/ThreadPriorities.hpp>
 #include <Sts1CobcSw/Firmware/TopicsAndSubscribers.hpp>
 #include <Sts1CobcSw/FramSections/FramLayout.hpp>

--- a/Sts1CobcSw/Firmware/EduHeartbeatThread.cpp
+++ b/Sts1CobcSw/Firmware/EduHeartbeatThread.cpp
@@ -1,4 +1,4 @@
-#include <Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>
+#include <Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>
 #include <Sts1CobcSw/Firmware/ThreadPriorities.hpp>
 #include <Sts1CobcSw/Firmware/TopicsAndSubscribers.hpp>
 #include <Sts1CobcSw/Hal/GpioPin.hpp>

--- a/Sts1CobcSw/Firmware/EduListenerThread.cpp
+++ b/Sts1CobcSw/Firmware/EduListenerThread.cpp
@@ -3,7 +3,7 @@
 #include <Sts1CobcSw/Edu/Types.hpp>
 #include <Sts1CobcSw/Firmware/EduCommunicationErrorThread.hpp>
 #include <Sts1CobcSw/Firmware/EduProgramQueueThread.hpp>
-#include <Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>
+#include <Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>
 #include <Sts1CobcSw/Firmware/ThreadPriorities.hpp>
 #include <Sts1CobcSw/Firmware/TopicsAndSubscribers.hpp>
 #include <Sts1CobcSw/Hal/GpioPin.hpp>

--- a/Sts1CobcSw/Firmware/EduPowerManagementThread.cpp
+++ b/Sts1CobcSw/Firmware/EduPowerManagementThread.cpp
@@ -1,5 +1,5 @@
 #include <Sts1CobcSw/Edu/Edu.hpp>
-#include <Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>
+#include <Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>
 #include <Sts1CobcSw/Firmware/ThreadPriorities.hpp>
 #include <Sts1CobcSw/Firmware/TopicsAndSubscribers.hpp>
 #include <Sts1CobcSw/FramSections/FramLayout.hpp>

--- a/Sts1CobcSw/Firmware/EduProgramQueueThread.cpp
+++ b/Sts1CobcSw/Firmware/EduProgramQueueThread.cpp
@@ -5,7 +5,7 @@
 #include <Sts1CobcSw/Edu/ProgramStatusHistory.hpp>
 #include <Sts1CobcSw/Edu/Types.hpp>
 #include <Sts1CobcSw/Firmware/EduCommunicationErrorThread.hpp>
-#include <Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>
+#include <Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>
 #include <Sts1CobcSw/Firmware/ThreadPriorities.hpp>
 #include <Sts1CobcSw/Firmware/TopicsAndSubscribers.hpp>
 #include <Sts1CobcSw/FramSections/FramLayout.hpp>

--- a/Sts1CobcSw/Firmware/EduProgramQueueThread.cpp
+++ b/Sts1CobcSw/Firmware/EduProgramQueueThread.cpp
@@ -50,8 +50,6 @@ public:
 private:
     void init() override
     {
-        edu::Initialize();
-
         // auto queueEntry1 = EduQueueEntry{
         //    .programId = 0, .timestamp = 1, .startTime = 946'684'807, .timeout = 10};  // NOLINT
 

--- a/Sts1CobcSw/Firmware/FlashStartupTestThread.cpp
+++ b/Sts1CobcSw/Firmware/FlashStartupTestThread.cpp
@@ -16,8 +16,8 @@ namespace sts1cobcsw
 {
 namespace
 {
-// Running the SpiSupervisor HW test showed that the minimum required stack size is ~560 bytes
-constexpr auto stackSize = 600;
+// Running the SpiSupervisor HW test in debug mode showed a max. stack usage of < 600 B
+constexpr auto stackSize = 800;
 
 
 class FlashStartupTestThread : public RODOS::StaticThread<stackSize>
@@ -36,7 +36,7 @@ private:
     void run() override
     {
         SuspendUntil(endOfTime);
-        DEBUG_PRINT("Flash start-up test ...");
+        DEBUG_PRINT("Flash start-up test ...\n");
         flash::Initialize();
         auto jedecId = flash::ReadJedecId();
         if(jedecId.deviceId == flash::correctJedecId.deviceId
@@ -46,9 +46,10 @@ private:
         }
         else
         {
-            DEBUG_PRINT(" failed to read correct flash JEDEC ID");
+            DEBUG_PRINT("  failed to read correct flash JEDEC ID\n");
             persistentVariables.Store<"flashIsWorking">(false);
         }
+        DEBUG_PRINT_STACK_USAGE();
         ResumeSpiStartupTestAndSupervisorThread();
         SuspendUntil(endOfTime);
     }

--- a/Sts1CobcSw/Firmware/FlashStartupTestThread.cpp
+++ b/Sts1CobcSw/Firmware/FlashStartupTestThread.cpp
@@ -1,6 +1,6 @@
 #include <Sts1CobcSw/Firmware/FlashStartupTestThread.hpp>
 
-#include <Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>
+#include <Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>
 #include <Sts1CobcSw/Firmware/ThreadPriorities.hpp>
 #include <Sts1CobcSw/Flash/Flash.hpp>
 #include <Sts1CobcSw/FramSections/FramLayout.hpp>
@@ -50,7 +50,7 @@ private:
             persistentVariables.Store<"flashIsWorking">(false);
         }
         DEBUG_PRINT_STACK_USAGE();
-        ResumeSpiStartupTestAndSupervisorThread();
+        ResumeStartupAndSpiSupervisorThread();
         SuspendUntil(endOfTime);
     }
 } flashStartupTestThread;

--- a/Sts1CobcSw/Firmware/FramEpsStartupTestThread.cpp
+++ b/Sts1CobcSw/Firmware/FramEpsStartupTestThread.cpp
@@ -20,8 +20,8 @@ namespace sts1cobcsw
 {
 namespace
 {
-// Running a reduced version of the firmware (without the EDU threads) showed that >900 B are needed
-constexpr auto stackSize = 1000;
+// Running the SpiSupervisor HW test in debug mode showed a max. stack usage of < 1000 B
+constexpr auto stackSize = 1200;
 
 
 class FramEpsStartupTestThread : public RODOS::StaticThread<stackSize>
@@ -40,7 +40,7 @@ private:
     void run() override
     {
         SuspendUntil(endOfTime);
-        DEBUG_PRINT("FRAM/EPS start-up test ...");
+        DEBUG_PRINT("FRAM/EPS start-up test ...\n");
         fram::Initialize();
         auto deviceId = fram::ReadDeviceId();
         if(deviceId == fram::correctDeviceId)
@@ -49,7 +49,7 @@ private:
         }
         else
         {
-            DEBUG_PRINT(" failed to read correct FRAM device ID");
+            DEBUG_PRINT("  failed to read correct FRAM device ID\n");
             fram::framIsWorking.Store(false);
         }
         persistentVariables.Store<"epsIsWorking">(true);
@@ -57,12 +57,14 @@ private:
         auto adcData = eps::ReadAdcs();
         if(adcData == eps::AdcData{})
         {
+            DEBUG_PRINT("  failed to read ADC data from EPS\n");
             persistentVariables.Store<"epsIsWorking">(false);
         }
         else
         {
             persistentVariables.Store<"epsIsWorking">(true);
         }
+        DEBUG_PRINT_STACK_USAGE();
         ResumeSpiStartupTestAndSupervisorThread();
         SuspendUntil(endOfTime);
     }

--- a/Sts1CobcSw/Firmware/FramEpsStartupTestThread.cpp
+++ b/Sts1CobcSw/Firmware/FramEpsStartupTestThread.cpp
@@ -1,6 +1,6 @@
 #include <Sts1CobcSw/Firmware/FramEpsStartupTestThread.hpp>
 
-#include <Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>
+#include <Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>
 #include <Sts1CobcSw/Firmware/ThreadPriorities.hpp>
 #include <Sts1CobcSw/Fram/Fram.hpp>
 #include <Sts1CobcSw/FramSections/FramLayout.hpp>
@@ -65,7 +65,7 @@ private:
             persistentVariables.Store<"epsIsWorking">(true);
         }
         DEBUG_PRINT_STACK_USAGE();
-        ResumeSpiStartupTestAndSupervisorThread();
+        ResumeStartupAndSpiSupervisorThread();
         SuspendUntil(endOfTime);
     }
 } framEpsStartupTestThread;

--- a/Sts1CobcSw/Firmware/RfCommunicationThread.cpp
+++ b/Sts1CobcSw/Firmware/RfCommunicationThread.cpp
@@ -5,7 +5,6 @@
 #include <Sts1CobcSw/Edu/Types.hpp>
 #include <Sts1CobcSw/FileSystem/DirectoryIterator.hpp>
 #include <Sts1CobcSw/FileSystem/FileSystem.hpp>
-#include <Sts1CobcSw/FileSystem/LfsMemoryDevice.hpp>
 #include <Sts1CobcSw/Firmware/FileTransferThread.hpp>
 #include <Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>
 #include <Sts1CobcSw/Firmware/ThreadPriorities.hpp>
@@ -149,14 +148,6 @@ private:
     {
         SuspendFor(totalStartupTestTimeout);  // Wait for the startup tests to complete
         DEBUG_PRINT("Starting RF communication thread\n");
-        rdt::Initialize();
-        fs::Initialize();
-        auto mountResult = fs::Mount();
-        if(mountResult.has_error())
-        {
-            DEBUG_PRINT("Failed to mount file system: %s\n", ToCZString(mountResult.error()));
-            persistentVariables.Increment<"nFileSystemErrors">();
-        }
         auto moreDataShouldBeReceived = false;
         while(true)
         {

--- a/Sts1CobcSw/Firmware/RfCommunicationThread.cpp
+++ b/Sts1CobcSw/Firmware/RfCommunicationThread.cpp
@@ -750,9 +750,11 @@ auto Set(Parameter parameter) -> void
     {
         case Parameter::Id::rxDataRate:
             rf::SetRxDataRate(parameter.value);
+            rxDataRateTopic.publish(parameter.value);
             break;
         case Parameter::Id::txDataRate:
             rf::SetTxDataRate(parameter.value);
+            txDataRateTopic.publish(parameter.value);
             break;
         case Parameter::Id::realTimeOffsetCorrection:
             persistentVariables.Store<"realTimeOffsetCorrection">(parameter.value * s);

--- a/Sts1CobcSw/Firmware/RfCommunicationThread.cpp
+++ b/Sts1CobcSw/Firmware/RfCommunicationThread.cpp
@@ -5,6 +5,7 @@
 #include <Sts1CobcSw/Edu/Types.hpp>
 #include <Sts1CobcSw/FileSystem/DirectoryIterator.hpp>
 #include <Sts1CobcSw/FileSystem/FileSystem.hpp>
+#include <Sts1CobcSw/FileSystem/LfsMemoryDevice.hpp>
 #include <Sts1CobcSw/Firmware/FileTransferThread.hpp>
 #include <Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>
 #include <Sts1CobcSw/Firmware/ThreadPriorities.hpp>
@@ -149,6 +150,13 @@ private:
         SuspendFor(totalStartupTestTimeout);  // Wait for the startup tests to complete
         DEBUG_PRINT("Starting RF communication thread\n");
         rdt::Initialize();
+        fs::Initialize();
+        auto mountResult = fs::Mount();
+        if(mountResult.has_error())
+        {
+            DEBUG_PRINT("Failed to mount file system: %s\n", ToCZString(mountResult.error()));
+            persistentVariables.Increment<"nFileSystemErrors">();
+        }
         auto moreDataShouldBeReceived = false;
         while(true)
         {

--- a/Sts1CobcSw/Firmware/RfCommunicationThread.cpp
+++ b/Sts1CobcSw/Firmware/RfCommunicationThread.cpp
@@ -65,7 +65,7 @@ namespace sts1cobcsw
 {
 namespace
 {
-constexpr auto stackSize = 4000;
+constexpr auto stackSize = 6000;
 constexpr auto rxTimeoutForAdditionalData = 3 * s;
 constexpr auto rxTimeoutAfterTelemetryRecord = 5 * s;
 // The ground station needs some time to switch from TX to RX so we need to wait for that when
@@ -159,6 +159,7 @@ private:
                 DEBUG_PRINT("Receiving for %" PRIi64 " s\n", rxTimeoutAfterTelemetryRecord / s);
                 auto receiveResult = ReceiveAndHandleData(rxTimeoutAfterTelemetryRecord);
                 moreDataShouldBeReceived = receiveResult.has_value();
+                DEBUG_PRINT_STACK_USAGE();
                 continue;
             }
             if(encodedCfdpFrameMailbox.IsFull())

--- a/Sts1CobcSw/Firmware/RfCommunicationThread.cpp
+++ b/Sts1CobcSw/Firmware/RfCommunicationThread.cpp
@@ -7,7 +7,7 @@
 #include <Sts1CobcSw/FileSystem/FileSystem.hpp>
 #include <Sts1CobcSw/FileSystem/LfsMemoryDevice.hpp>
 #include <Sts1CobcSw/Firmware/FileTransferThread.hpp>
-#include <Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>
+#include <Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>
 #include <Sts1CobcSw/Firmware/ThreadPriorities.hpp>
 #include <Sts1CobcSw/Firmware/TopicsAndSubscribers.hpp>
 #include <Sts1CobcSw/FirmwareManagement/FirmwareManagement.hpp>

--- a/Sts1CobcSw/Firmware/RfStartupTestThread.cpp
+++ b/Sts1CobcSw/Firmware/RfStartupTestThread.cpp
@@ -16,9 +16,8 @@ namespace sts1cobcsw
 {
 namespace
 {
-// Running the SpiSupervisor HW test in debug mode showed that the minimum required stack size is
-// between 1400 and 1800 bytes
-constexpr auto stackSize = 1800;
+// Running the SpiSupervisor HW test in debug mode showed a max. stack usage of < 1500 B
+constexpr auto stackSize = 2000;
 
 
 class RfStartupTestThread : public RODOS::StaticThread<stackSize>
@@ -36,19 +35,19 @@ private:
     void run() override
     {
         SuspendUntil(endOfTime);
-        DEBUG_PRINT("RF start-up test ...");
+        DEBUG_PRINT("RF start-up test ...\n");
         auto testSucceeded = [&]() -> bool
         {
             auto initializeResult = rf::Initialize(rf::TxType::packet);
             if(initializeResult.has_error())
             {
-                DEBUG_PRINT(" failed to initialize RF module");
+                DEBUG_PRINT("  failed to initialize RF module\n");
                 return false;
             }
             auto partNumber = rf::ReadPartNumber();
             if(partNumber != rf::correctPartNumber)
             {
-                DEBUG_PRINT(" failed to read correct RF part number");
+                DEBUG_PRINT("  failed to read correct RF part number\n");
                 return false;
             }
             return true;
@@ -62,6 +61,7 @@ private:
             persistentVariables.Store<"rfIsWorking">(false);
             persistentVariables.Increment<"nRfErrors">();
         }
+        DEBUG_PRINT_STACK_USAGE();
         ResumeSpiStartupTestAndSupervisorThread();
         SuspendUntil(endOfTime);
     }

--- a/Sts1CobcSw/Firmware/RfStartupTestThread.cpp
+++ b/Sts1CobcSw/Firmware/RfStartupTestThread.cpp
@@ -2,6 +2,7 @@
 
 #include <Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>
 #include <Sts1CobcSw/Firmware/ThreadPriorities.hpp>
+#include <Sts1CobcSw/Firmware/TopicsAndSubscribers.hpp>
 #include <Sts1CobcSw/FramSections/FramLayout.hpp>
 #include <Sts1CobcSw/FramSections/PersistentVariables.hpp>
 #include <Sts1CobcSw/Rf/Rf.hpp>
@@ -50,6 +51,8 @@ private:
                 DEBUG_PRINT("  failed to read correct RF part number\n");
                 return false;
             }
+            rxDataRateTopic.publish(rf::GetRxDataRate());
+            txDataRateTopic.publish(rf::GetTxDataRate());
             return true;
         }();
         if(testSucceeded)

--- a/Sts1CobcSw/Firmware/RfStartupTestThread.cpp
+++ b/Sts1CobcSw/Firmware/RfStartupTestThread.cpp
@@ -1,6 +1,6 @@
 #include <Sts1CobcSw/Firmware/RfStartupTestThread.hpp>
 
-#include <Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>
+#include <Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>
 #include <Sts1CobcSw/Firmware/ThreadPriorities.hpp>
 #include <Sts1CobcSw/Firmware/TopicsAndSubscribers.hpp>
 #include <Sts1CobcSw/FramSections/FramLayout.hpp>
@@ -65,7 +65,7 @@ private:
             persistentVariables.Increment<"nRfErrors">();
         }
         DEBUG_PRINT_STACK_USAGE();
-        ResumeSpiStartupTestAndSupervisorThread();
+        ResumeStartupAndSpiSupervisorThread();
         SuspendUntil(endOfTime);
     }
 } rfStartupTestThread;

--- a/Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.cpp
+++ b/Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.cpp
@@ -1,4 +1,4 @@
-#include <Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>
+#include <Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>
 
 #include <Sts1CobcSw/Firmware/FlashStartupTestThread.hpp>
 #include <Sts1CobcSw/Firmware/FramEpsStartupTestThread.hpp>
@@ -40,12 +40,11 @@ constexpr auto supervisionPeriod = 1 * s;
 auto ExecuteStartupTest(void (*startupTestThreadResumeFuntion)()) -> bool;
 
 
-class SpiStartupTestAndSupervisorThread : public RODOS::StaticThread<stackSize>
+class StartupAndSpiSupervisorThread : public RODOS::StaticThread<stackSize>
 {
 public:
-    SpiStartupTestAndSupervisorThread()
-        : StaticThread("SpiStartupTestAndSupervisorThread",
-                       spiStartupTestAndSupervisorThreadPriority)
+    StartupAndSpiSupervisorThread()
+        : StaticThread("StartupAndSpiSupervisorThread", startupAndSpiSupervisorThreadPriority)
     {}
 
 
@@ -144,13 +143,13 @@ private:
             }
         }
     }
-} spiStartupTestAndSupervisorThread;
+} startupAndSpiSupervisorThread;
 }
 
 
-auto ResumeSpiStartupTestAndSupervisorThread() -> void
+auto ResumeStartupAndSpiSupervisorThread() -> void
 {
-    spiStartupTestAndSupervisorThread.resume();
+    startupAndSpiSupervisorThread.resume();
 }
 
 

--- a/Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.cpp
+++ b/Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.cpp
@@ -1,5 +1,8 @@
 #include <Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>
 
+#include <Sts1CobcSw/Edu/Edu.hpp>
+#include <Sts1CobcSw/FileSystem/FileSystem.hpp>
+#include <Sts1CobcSw/FileSystem/LfsMemoryDevice.hpp>
 #include <Sts1CobcSw/Firmware/FlashStartupTestThread.hpp>
 #include <Sts1CobcSw/Firmware/FramEpsStartupTestThread.hpp>
 #include <Sts1CobcSw/Firmware/RfStartupTestThread.hpp>
@@ -9,10 +12,14 @@
 #include <Sts1CobcSw/FramSections/PersistentVariables.hpp>
 #include <Sts1CobcSw/Hal/Spi.hpp>
 #include <Sts1CobcSw/Hal/Spis.hpp>
+#include <Sts1CobcSw/Outcome/Outcome.hpp>
 #include <Sts1CobcSw/RodosTime/RodosTime.hpp>
 #include <Sts1CobcSw/Utility/DebugPrint.hpp>
 #include <Sts1CobcSw/Utility/ErrorDetectionAndCorrection.hpp>
 #include <Sts1CobcSw/Vocabulary/Time.hpp>
+#ifndef __linux__
+    #include <Sts1CobcSw/WatchdogTimers/WatchdogTimers.hpp>
+#endif
 
 #include <strong_type/affine_point.hpp>
 #include <strong_type/difference.hpp>
@@ -28,16 +35,19 @@ namespace sts1cobcsw
 {
 namespace
 {
-// Running the SpiSupervisor HW test in debug mode showed a max. stack usage of < 700 B. The golden
-// test needs < 800 B.
-constexpr auto stackSize = 1000 + EXTRA_SANITIZER_STACK_SIZE;
+// Running the SpiSupervisor HW test in debug mode showed a max. stack usage of < 1600 B. The golden
+// test needs < 2400 B.
+constexpr auto stackSize = 2500 + EXTRA_SANITIZER_STACK_SIZE;
 
 inline constexpr auto initialSleepTime = 10 * ms;
 // TODO: Think about how often the supervision should run
 constexpr auto supervisionPeriod = 1 * s;
 
 
+auto ExecuteStartupTests() -> void;
 auto ExecuteStartupTest(void (*startupTestThreadResumeFuntion)()) -> bool;
+auto InitializeAndFeedResetDog() -> void;
+auto SetUpFileSystem() -> void;
 
 
 class StartupAndSpiSupervisorThread : public RODOS::StaticThread<stackSize>
@@ -49,58 +59,12 @@ public:
 
 
 private:
-    void init() override
-    {}
-
-
     void run() override
     {
         // Briefly go to sleep to ensure that the low-priority startup test threads have started and
         // are waiting for the high-priority supervisor thread to resume them
         SuspendFor(initialSleepTime);
-
-        // The messages are only used in DEBUG_PRINT() calls, so they are unused in release builds
-        [[maybe_unused]] static constexpr auto errorMessage = " failed to complete in time\n";
-        [[maybe_unused]] static constexpr auto successMessage = " completed in time\n";
-
-        auto testWasSuccessful = ExecuteStartupTest(ResumeFramEpsStartupTestThread);
-        DEBUG_PRINT(fram::framIsWorking.Load() ? " " : " and");
-        if(not testWasSuccessful)
-        {
-            DEBUG_PRINT("%s", errorMessage);
-            fram::framIsWorking.Store(false);
-            persistentVariables.Store<"epsIsWorking">(false);
-        }
-        else
-        {
-            DEBUG_PRINT("%s", successMessage);
-        }
-
-        testWasSuccessful = ExecuteStartupTest(ResumeFlashStartupTestThread);
-        DEBUG_PRINT(persistentVariables.Load<"flashIsWorking">() ? " " : " and");
-        if(not testWasSuccessful)
-        {
-            DEBUG_PRINT("%s", errorMessage);
-            persistentVariables.Store<"flashIsWorking">(false);
-            persistentVariables.Increment<"nFlashErrors">();
-        }
-        else
-        {
-            DEBUG_PRINT("%s", successMessage);
-        }
-
-        testWasSuccessful = ExecuteStartupTest(ResumeRfStartupTestThread);
-        DEBUG_PRINT(persistentVariables.Load<"rfIsWorking">() ? " " : " and");
-        if(not testWasSuccessful)
-        {
-            DEBUG_PRINT("%s", errorMessage);
-            persistentVariables.Store<"rfIsWorking">(false);
-            persistentVariables.Increment<"nRfErrors">();
-        }
-        else
-        {
-            DEBUG_PRINT("%s", successMessage);
-        }
+        ExecuteStartupTests();
         DEBUG_PRINT_STACK_USAGE();
         if(not persistentVariables.Load<"rfIsWorking">())
         {
@@ -109,7 +73,9 @@ private:
             SuspendFor(2 * s);
             RODOS::hwResetAndReboot();
         }
-
+        InitializeAndFeedResetDog();
+        SetUpFileSystem();
+        edu::Initialize();
         auto i = 0U;
         TIME_LOOP(0, value_of(supervisionPeriod))
         {
@@ -155,12 +121,97 @@ auto ResumeStartupAndSpiSupervisorThread() -> void
 
 namespace
 {
+auto ExecuteStartupTests() -> void
+{
+    // The messages are only used in DEBUG_PRINT() calls, so they are unused in release builds
+    [[maybe_unused]] static constexpr auto errorMessage = " failed to complete in time\n";
+    [[maybe_unused]] static constexpr auto successMessage = " completed in time\n";
+
+    auto testWasSuccessful = ExecuteStartupTest(ResumeFramEpsStartupTestThread);
+    DEBUG_PRINT(fram::framIsWorking.Load() ? " " : " and");
+    if(not testWasSuccessful)
+    {
+        DEBUG_PRINT("%s", errorMessage);
+        fram::framIsWorking.Store(false);
+        persistentVariables.Store<"epsIsWorking">(false);
+    }
+    else
+    {
+        DEBUG_PRINT("%s", successMessage);
+    }
+
+    testWasSuccessful = ExecuteStartupTest(ResumeFlashStartupTestThread);
+    DEBUG_PRINT(persistentVariables.Load<"flashIsWorking">() ? " " : " and");
+    if(not testWasSuccessful)
+    {
+        DEBUG_PRINT("%s", errorMessage);
+        persistentVariables.Store<"flashIsWorking">(false);
+        persistentVariables.Increment<"nFlashErrors">();
+    }
+    else
+    {
+        DEBUG_PRINT("%s", successMessage);
+    }
+
+    testWasSuccessful = ExecuteStartupTest(ResumeRfStartupTestThread);
+    DEBUG_PRINT(persistentVariables.Load<"rfIsWorking">() ? " " : " and");
+    if(not testWasSuccessful)
+    {
+        DEBUG_PRINT("%s", errorMessage);
+        persistentVariables.Store<"rfIsWorking">(false);
+        persistentVariables.Increment<"nRfErrors">();
+    }
+    else
+    {
+        DEBUG_PRINT("%s", successMessage);
+    }
+}
+
+
 auto ExecuteStartupTest(void (*startupTestThreadResumeFuntion)()) -> bool
 {
     auto testEnd = CurrentRodosTime() + startupTestTimeout;
     startupTestThreadResumeFuntion();
     SuspendUntil(testEnd);
     return CurrentRodosTime() <= testEnd;
+}
+
+
+auto InitializeAndFeedResetDog() -> void
+{
+#ifndef __linux__
+    rdt::Initialize();
+    // We need to feed the reset dog right away since the startup tests can take up to 650 ms
+    rdt::Feed();
+#endif
+}
+
+
+auto SetUpFileSystem() -> void
+{
+    fs::Initialize();
+    auto mountResult = fs::Mount();
+    if(mountResult.has_error())
+    {
+        DEBUG_PRINT("Failed to mount file system: %s\n", ToCZString(mountResult.error()));
+        persistentVariables.Increment<"nFileSystemErrors">();
+    }
+    auto createDirectoryResult = fs::CreateDirectory("/programs");
+    if(createDirectoryResult.has_error()
+       and createDirectoryResult.error() != ErrorCode::alreadyExists)
+    {
+        DEBUG_PRINT("Failed to create directory /programs: %s\n",
+                    ToCZString(createDirectoryResult.error()));
+        persistentVariables.Increment<"nFileSystemErrors">();
+    }
+    createDirectoryResult = fs::CreateDirectory("/results");
+    if(createDirectoryResult.has_error()
+       and createDirectoryResult.error() != ErrorCode::alreadyExists)
+    {
+        DEBUG_PRINT("Failed to create directory /results: %s\n",
+                    ToCZString(createDirectoryResult.error()));
+        persistentVariables.Increment<"nFileSystemErrors">();
+    }
 }
 }
 }

--- a/Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp
+++ b/Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp
@@ -14,5 +14,5 @@ namespace sts1cobcsw
 // TODO: Measure how long the startup tests really take to determine the correct timeouts
 inline constexpr auto startupTestTimeout = 200 * ms;
 inline constexpr auto totalStartupTestTimeout = 3 * startupTestTimeout + 50 * ms;
-auto ResumeSpiStartupTestAndSupervisorThread() -> void;
+auto ResumeStartupAndSpiSupervisorThread() -> void;
 }

--- a/Sts1CobcSw/Firmware/StartupTestThreadStubs.cpp
+++ b/Sts1CobcSw/Firmware/StartupTestThreadStubs.cpp
@@ -34,7 +34,7 @@ private:
     void run() override
     {
         SuspendUntil(endOfTime);
-        DEBUG_PRINT("FRAM/EPS start-up test ...");
+        DEBUG_PRINT("FRAM/EPS start-up test ...\n");
         fram::framIsWorking.Store(true);
         persistentVariables.Store<"epsIsWorking">(true);
         ResumeSpiStartupTestAndSupervisorThread();
@@ -59,7 +59,7 @@ private:
     void run() override
     {
         SuspendUntil(endOfTime);
-        DEBUG_PRINT("Flash start-up test ...");
+        DEBUG_PRINT("Flash start-up test ...\n");
         persistentVariables.Store<"flashIsWorking">(true);
         ResumeSpiStartupTestAndSupervisorThread();
         SuspendUntil(endOfTime);
@@ -82,7 +82,7 @@ private:
     void run() override
     {
         SuspendUntil(endOfTime);
-        DEBUG_PRINT("RF start-up test ...");
+        DEBUG_PRINT("RF start-up test ...\n");
         persistentVariables.Store<"rfIsWorking">(true);
         ResumeSpiStartupTestAndSupervisorThread();
         SuspendUntil(endOfTime);

--- a/Sts1CobcSw/Firmware/StartupTestThreadStubs.cpp
+++ b/Sts1CobcSw/Firmware/StartupTestThreadStubs.cpp
@@ -1,4 +1,4 @@
-#include <Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>
+#include <Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>
 #include <Sts1CobcSw/Firmware/ThreadPriorities.hpp>
 #include <Sts1CobcSw/Fram/Fram.hpp>
 #include <Sts1CobcSw/FramSections/FramLayout.hpp>
@@ -37,7 +37,7 @@ private:
         DEBUG_PRINT("FRAM/EPS start-up test ...\n");
         fram::framIsWorking.Store(true);
         persistentVariables.Store<"epsIsWorking">(true);
-        ResumeSpiStartupTestAndSupervisorThread();
+        ResumeStartupAndSpiSupervisorThread();
         SuspendUntil(endOfTime);
     }
 } framEpsStartupTestThread;
@@ -61,7 +61,7 @@ private:
         SuspendUntil(endOfTime);
         DEBUG_PRINT("Flash start-up test ...\n");
         persistentVariables.Store<"flashIsWorking">(true);
-        ResumeSpiStartupTestAndSupervisorThread();
+        ResumeStartupAndSpiSupervisorThread();
         SuspendUntil(endOfTime);
     }
 } flashStartupTestThread;
@@ -84,7 +84,7 @@ private:
         SuspendUntil(endOfTime);
         DEBUG_PRINT("RF start-up test ...\n");
         persistentVariables.Store<"rfIsWorking">(true);
-        ResumeSpiStartupTestAndSupervisorThread();
+        ResumeStartupAndSpiSupervisorThread();
         SuspendUntil(endOfTime);
     }
 } rfStartupTestThread;

--- a/Sts1CobcSw/Firmware/TelemetryThread.cpp
+++ b/Sts1CobcSw/Firmware/TelemetryThread.cpp
@@ -73,9 +73,9 @@ auto CollectTelemetryData() -> TelemetryRecord
     eduIsAliveBufferForTelemetry.get(eduIsAlive);
     auto programIdOfCurrentEduProgramQueueEntry = ProgramId(0);
     programIdOfCurrentEduProgramQueueEntryBuffer.get(programIdOfCurrentEduProgramQueueEntry);
-    std::int32_t rxDataRate = 0;
+    std::uint32_t rxDataRate = 0;
     rxDataRateBuffer.get(rxDataRate);
-    std::int32_t txDataRate = 0;
+    std::uint32_t txDataRate = 0;
     txDataRateBuffer.get(txDataRate);
     return TelemetryRecord{
         // Booleans: byte 1: EDU and housekeeping

--- a/Sts1CobcSw/Firmware/TelemetryThread.cpp
+++ b/Sts1CobcSw/Firmware/TelemetryThread.cpp
@@ -34,7 +34,7 @@ namespace sts1cobcsw
 {
 namespace
 {
-constexpr auto stackSize = 1000U;
+constexpr auto stackSize = 1200U;
 constexpr auto telemetryThreadInterval = 30 * s;
 
 
@@ -62,6 +62,7 @@ private:
             telemetryRecordMailbox.Overwrite(telemetryRecord);
             nextTelemetryRecordTimeMailbox.Overwrite(CurrentRodosTime() + telemetryThreadInterval);
             ResumeRfCommunicationThread();
+            DEBUG_PRINT_STACK_USAGE();
         }
     }
 } telemetryThread;

--- a/Sts1CobcSw/Firmware/TelemetryThread.cpp
+++ b/Sts1CobcSw/Firmware/TelemetryThread.cpp
@@ -1,5 +1,5 @@
 #include <Sts1CobcSw/Firmware/RfCommunicationThread.hpp>
-#include <Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>
+#include <Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>
 #include <Sts1CobcSw/Firmware/ThreadPriorities.hpp>
 #include <Sts1CobcSw/Firmware/TopicsAndSubscribers.hpp>
 #include <Sts1CobcSw/Fram/Fram.hpp>

--- a/Sts1CobcSw/Firmware/ThreadPriorities.hpp
+++ b/Sts1CobcSw/Firmware/ThreadPriorities.hpp
@@ -17,6 +17,6 @@ inline constexpr auto eduHeartbeatThreadPriority = 260;
 inline constexpr auto fileTransferThreadPriority = 800;
 inline constexpr auto rfCommunicationThreadPriority = 900;
 inline constexpr auto telemetryThreadPriority = 910;
-inline constexpr auto spiStartupTestAndSupervisorThreadPriority = MAX_THREAD_PRIORITY;
+inline constexpr auto startupAndSpiSupervisorThreadPriority = MAX_THREAD_PRIORITY;
 static_assert(MAX_THREAD_PRIORITY == 1000);  // NOLINT(*magic-numbers)
 }

--- a/Sts1CobcSw/Firmware/TopicsAndSubscribers.hpp
+++ b/Sts1CobcSw/Firmware/TopicsAndSubscribers.hpp
@@ -35,11 +35,11 @@ inline auto programIdOfCurrentEduProgramQueueEntryTopic =
     RODOS::Topic<ProgramId>(-1, "programIdOfCurrentEduProgramQueueEntryTopic");
 inline auto programIdOfCurrentEduProgramQueueEntryBuffer = RODOS::CommBuffer<ProgramId>{};
 
-inline auto rxDataRateTopic = RODOS::Topic<std::int32_t>(-1, "rxDataRateTopic");
-inline auto rxDataRateBuffer = RODOS::CommBuffer<std::int32_t>{};
+inline auto rxDataRateTopic = RODOS::Topic<std::uint32_t>(-1, "rxDataRateTopic");
+inline auto rxDataRateBuffer = RODOS::CommBuffer<std::uint32_t>{};
 
-inline auto txDataRateTopic = RODOS::Topic<std::int32_t>(-1, "txDataRateTopic");
-inline auto txDataRateBuffer = RODOS::CommBuffer<std::int32_t>{};
+inline auto txDataRateTopic = RODOS::Topic<std::uint32_t>(-1, "txDataRateTopic");
+inline auto txDataRateBuffer = RODOS::CommBuffer<std::uint32_t>{};
 
 // We only send the telemetry records from the telemetry thread to the RF communication thread, so
 // we don't need the whole publisher/subscriber mechanism here. A simple mailbox is enough.

--- a/Sts1CobcSw/Rf/RfOverUci.cpp
+++ b/Sts1CobcSw/Rf/RfOverUci.cpp
@@ -40,6 +40,11 @@ auto txDataRate = uartBaudRate;
 auto Initialize([[maybe_unused]] TxType txType) -> Result<void>
 {
     hal::Initialize(&uciUart, uartBaudRate);
+    // The real RF module takes > 100 ms to initialize so we simulate this with a busy wait. Without
+    // this delay, the SPI supervisor test crashes for some reason when printing stack usage is
+    // enabled. I suspect that RODOS::PRINTF() is non-blocking and with all the printing we overflow
+    // the UART buffer.
+    BusyWaitFor(100 * ms);  // NOLINT(*magic-numbers)
     return outcome_v2::success();
 }
 

--- a/Sts1CobcSw/Rf/RfOverUci.cpp
+++ b/Sts1CobcSw/Rf/RfOverUci.cpp
@@ -141,12 +141,12 @@ auto SuspendUntilDataSent([[maybe_unused]] Duration timeout) -> void
 auto Receive(std::span<Byte> data, Duration timeout) -> std::size_t
 {
     auto result = hal::ReadFrom(&uciUart, data, timeout);
+    // Add a line break after receiving the data, for nicer formatting in HTerm.
+    (void)hal::WriteTo(&uciUart, Span(endOfFrame), frameDelimiterTimeout);
     if(result.has_error())
     {
         return 0;
     }
-    // Add a line break after receiving the data, for nicer formatting in HTerm.
-    (void)hal::WriteTo(&uciUart, Span(endOfFrame), frameDelimiterTimeout);
     return data.size();
 }
 }

--- a/Sts1CobcSw/Telemetry/TelemetryRecord.hpp
+++ b/Sts1CobcSw/Telemetry/TelemetryRecord.hpp
@@ -59,8 +59,8 @@ struct TelemetryRecord
     eps::AdcData epsAdcData = {};
 
     // Communication
-    std::int32_t rxDataRate = 0;
-    std::int32_t txDataRate = 0;
+    std::uint32_t rxDataRate = 0;
+    std::uint32_t txDataRate = 0;
     std::uint16_t nCorrectableUplinkErrors = 0U;
     std::uint16_t nUncorrectableUplinkErrors = 0U;
     std::uint16_t nGoodTransferFrames = 0U;

--- a/Sts1CobcSw/Utility/CMakeLists.txt
+++ b/Sts1CobcSw/Utility/CMakeLists.txt
@@ -4,3 +4,6 @@ target_link_libraries(Sts1CobcSw_Utility PRIVATE littlefs::littlefs)
 target_compile_definitions(
     Sts1CobcSw_Utility PUBLIC $<$<CONFIG:Debug,RelWithDebInfo>:ENABLE_DEBUG_PRINT>
 )
+if(ENABLE_DEBUG_PRINT_STACK_USAGE)
+    target_compile_definitions(Sts1CobcSw_Utility PUBLIC ENABLE_DEBUG_PRINT_STACK_USAGE)
+endif()

--- a/Sts1CobcSw/Utility/DebugPrint.hpp
+++ b/Sts1CobcSw/Utility/DebugPrint.hpp
@@ -9,7 +9,13 @@
     #pragma GCC diagnostic ignored "-Wpedantic"
     // NOLINTNEXTLINE(cppcoreguidelines-macro-usage, *variadic-macro-arguments)
     #define DEBUG_PRINT(fmt, ...) RODOS::PRINTF(fmt, ##__VA_ARGS__)
+    #define DEBUG_PRINT_STACK_USAGE() \
+        RODOS::PRINTF("[%s#%i] max. stack usage = %5u B\n", \
+                      __FILE_NAME__, \
+                      __LINE__, \
+                      getMaxStackUsage())
     #pragma GCC diagnostic pop
 #else
     #define DEBUG_PRINT(fmt, ...)
+    #define DEBUG_PRINT_STACK_USAGE()
 #endif

--- a/Sts1CobcSw/Utility/DebugPrint.hpp
+++ b/Sts1CobcSw/Utility/DebugPrint.hpp
@@ -9,13 +9,15 @@
     #pragma GCC diagnostic ignored "-Wpedantic"
     // NOLINTNEXTLINE(cppcoreguidelines-macro-usage, *variadic-macro-arguments)
     #define DEBUG_PRINT(fmt, ...) RODOS::PRINTF(fmt, ##__VA_ARGS__)
-    #define DEBUG_PRINT_STACK_USAGE() \
-        RODOS::PRINTF("[%s#%i] max. stack usage = %5u B\n", \
-                      __FILE_NAME__, \
-                      __LINE__, \
-                      getMaxStackUsage())
     #pragma GCC diagnostic pop
 #else
     #define DEBUG_PRINT(fmt, ...)
+#endif
+
+#ifdef ENABLE_DEBUG_PRINT_STACK_USAGE
+    #define DEBUG_PRINT_STACK_USAGE() \
+        DEBUG_PRINT( \
+            "[%s#%i] max. stack usage = %5u B\n", __FILE_NAME__, __LINE__, getMaxStackUsage())
+#else
     #define DEBUG_PRINT_STACK_USAGE()
 #endif

--- a/Tests/IntegrationTests/CMakeLists.txt
+++ b/Tests/IntegrationTests/CMakeLists.txt
@@ -18,7 +18,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     target_sources(
         Sts1CobcSwTests_SpiSupervisor
         PRIVATE ${CMAKE_SOURCE_DIR}/Sts1CobcSw/Firmware/StartupTestThreadStubs.cpp
-                ${CMAKE_SOURCE_DIR}/Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.cpp
+                ${CMAKE_SOURCE_DIR}/Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.cpp
     )
     target_link_libraries(
         Sts1CobcSwTests_SpiSupervisor

--- a/Tests/IntegrationTests/CMakeLists.txt
+++ b/Tests/IntegrationTests/CMakeLists.txt
@@ -23,6 +23,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     target_link_libraries(
         Sts1CobcSwTests_SpiSupervisor
         PRIVATE rodos::rodos
+                Sts1CobcSw_Edu
+                Sts1CobcSw_FileSystem
                 Sts1CobcSw_Fram
                 Sts1CobcSw_FramSections
                 Sts1CobcSw_Hal

--- a/Tests/IntegrationTests/ExpectedOutputs/SpiSupervisor.txt
+++ b/Tests/IntegrationTests/ExpectedOutputs/SpiSupervisor.txt
@@ -1,3 +1,4 @@
+/littlefs/lfs.c:1369:error: Corrupted dir pair at {0x0, 0x1}
 
 SPI supervisor test
 

--- a/Tests/IntegrationTests/ExpectedOutputs/SpiSupervisor_Debug.txt
+++ b/Tests/IntegrationTests/ExpectedOutputs/SpiSupervisor_Debug.txt
@@ -4,6 +4,7 @@ Flash start-up test ...
   completed in time
 RF start-up test ...
   completed in time
+/littlefs/lfs.c:1369:error: Corrupted dir pair at {0x0, 0x1}
 
 SPI supervisor test
 

--- a/Tests/IntegrationTests/ExpectedOutputs/SpiSupervisor_Debug.txt
+++ b/Tests/IntegrationTests/ExpectedOutputs/SpiSupervisor_Debug.txt
@@ -1,9 +1,9 @@
 FRAM/EPS start-up test ...
- completed in time
+  completed in time
 Flash start-up test ...
- completed in time
+  completed in time
 RF start-up test ...
- completed in time
+  completed in time
 
 SPI supervisor test
 

--- a/Tests/IntegrationTests/SpiSupervisor.test.cpp
+++ b/Tests/IntegrationTests/SpiSupervisor.test.cpp
@@ -1,4 +1,4 @@
-#include <Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>
+#include <Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>
 #include <Sts1CobcSw/Fram/Fram.hpp>
 #include <Sts1CobcSw/Fram/FramMock.hpp>
 #include <Sts1CobcSw/Hal/Spi.hpp>

--- a/Tests/ManualTests/CMakeLists.txt
+++ b/Tests/ManualTests/CMakeLists.txt
@@ -97,7 +97,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Generic)
         PRIVATE ${CMAKE_SOURCE_DIR}/Sts1CobcSw/Firmware/FlashStartupTestThread.cpp
                 ${CMAKE_SOURCE_DIR}/Sts1CobcSw/Firmware/FramEpsStartupTestThread.cpp
                 ${CMAKE_SOURCE_DIR}/Sts1CobcSw/Firmware/RfStartupTestThread.cpp
-                ${CMAKE_SOURCE_DIR}/Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.cpp
+                ${CMAKE_SOURCE_DIR}/Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.cpp
     )
     target_link_libraries(
         Sts1CobcSwTests_SpiSupervisor

--- a/Tests/ManualTests/CMakeLists.txt
+++ b/Tests/ManualTests/CMakeLists.txt
@@ -103,6 +103,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL Generic)
         Sts1CobcSwTests_SpiSupervisor
         PRIVATE rodos::rodos
                 strong_type::strong_type
+                Sts1CobcSw_Edu
+                Sts1CobcSw_FileSystem
                 Sts1CobcSw_Flash
                 Sts1CobcSw_Fram
                 Sts1CobcSw_FramSections
@@ -113,6 +115,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Generic)
                 Sts1CobcSw_Sensors
                 Sts1CobcSw_Utility
                 Sts1CobcSw_Vocabulary
+                Sts1CobcSw_WatchdogTimers
                 Sts1CobcSwTests::HardwareSetup
     )
 

--- a/Tests/ManualTests/SpiSupervisor.test.cpp
+++ b/Tests/ManualTests/SpiSupervisor.test.cpp
@@ -1,4 +1,4 @@
-#include <Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>
+#include <Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>
 #include <Sts1CobcSw/Flash/Flash.hpp>
 #include <Sts1CobcSw/Fram/Fram.hpp>
 #include <Sts1CobcSw/RodosTime/RodosTime.hpp>

--- a/Tests/UnitTests/FileSystem.test.cpp
+++ b/Tests/UnitTests/FileSystem.test.cpp
@@ -74,6 +74,10 @@ TEST_CASE("File system without data corruption")
     createDirResult = fs::CreateDirectory(dirPath);
     CHECK(createDirResult.has_error() == false);
 
+    createDirResult = fs::CreateDirectory(dirPath);
+    REQUIRE(createDirResult.has_error());
+    CHECK(createDirResult.error() == ErrorCode::alreadyExists);
+
     auto filePath = fs::Path("/MyDir/MyFile");
     auto openResult = fs::Open(filePath, LFS_O_WRONLY | LFS_O_CREAT);
     CHECK(openResult.has_value());

--- a/cmake/options-and-variables.cmake
+++ b/cmake/options-and-variables.cmake
@@ -26,6 +26,7 @@ if(REDIRECT_RF_OVER_UCI AND CMAKE_SYSTEM_NAME STREQUAL Linux)
 endif()
 
 option(DISABLE_CHANNEL_CODING "Do not encode and decode transfer frames" OFF)
+option(ENABLE_DEBUG_PRINT_STACK_USAGE "Enable printing of stack usage in debug builds" OFF)
 
 set(HW_VERSION 30 CACHE STRING "Hardware version")
 

--- a/cmake/run-golden-test.cmake
+++ b/cmake/run-golden-test.cmake
@@ -26,12 +26,26 @@ execute_process(COMMAND "${TEST_EXECUTABLE}" OUTPUT_VARIABLE output)
 
 set(rodos_header_regex ".*--------------- Application running ------------\n")
 string(REGEX REPLACE "${rodos_header_regex}" "" output_without_rodos_header ${output})
+set(stack_usage_regex "\\[[^\n]*\n")
+string(REGEX REPLACE "${stack_usage_regex}" "" output_without_rodos_header_and_stack_usage
+                     ${output_without_rodos_header}
+)
 
 file(READ "${EXPECTED_OUTPUT_FILE}" expected_output)
 
-if(output_without_rodos_header STREQUAL expected_output)
+if(output_without_rodos_header_and_stack_usage STREQUAL expected_output)
     message("Test passed ✔️")
 else()
     # TODO: Upgrade CMake to version 3.29 for cmake_language(EXIT 1)
-    message(FATAL_ERROR "Test failed ❌")
+    message("Test failed ❌")
+    message("--------------------------------------------------------------------------------")
+    message("Expected output:")
+    message("--------------------------------------------------------------------------------")
+    message("${expected_output}")
+    message("--------------------------------------------------------------------------------")
+    message("Actual output:")
+    message("--------------------------------------------------------------------------------")
+    message("${output_without_rodos_header_and_stack_usage}")
+    message("--------------------------------------------------------------------------------")
+    cmake_language(EXIT 1)
 endif()

--- a/iwyu.imp
+++ b/iwyu.imp
@@ -78,7 +78,7 @@
   { include: ["\"Sts1CobcSw/Firmware/FramEpsStartupTestThread.hpp\"",          "public", "<Sts1CobcSw/Firmware/FramEpsStartupTestThread.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Firmware/RfCommunicationThread.hpp\"",             "public", "<Sts1CobcSw/Firmware/RfCommunicationThread.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Firmware/RfStartupTestThread.hpp\"",               "public", "<Sts1CobcSw/Firmware/RfStartupTestThread.hpp>", "public"] },
-  { include: ["\"Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp\"", "public", "<Sts1CobcSw/Firmware/SpiStartupTestAndSupervisorThread.hpp>", "public"] },
+  { include: ["\"Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp\"", "public", "<Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Firmware/ThreadPriorites.hpp\"",                   "public", "<Sts1CobcSw/Firmware/ThreadPriorites.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Firmware/TopicsAndSubscribers.hpp\"",              "public", "<Sts1CobcSw/Firmware/TopicsAndSubscribers.hpp>", "public"] },
   { include: ["\"Sts1CobcSw/Edu/Edu.hpp\"",                                    "public", "<Sts1CobcSw/Edu/Edu.hpp>", "public"] },


### PR DESCRIPTION
Fixes #418

For the stack sizes, I added the CMake option `ENABLE_DEBUG_PRINT_STACK_SIZE` and macro `DEBUG_PRINT_STACK_SIZE()`. All initialization and startup code is moved to the `SpiStartupTestAndSupervisorThread` which is now called `StartupAndSpiSupervisorThread`. I also mounted and set up the file system there. Don't know how I forgot about that until now. Finally, I fixed that the RX and TX data rates not being published. I forgot about that when implementing the RF communication thread.