### PR TITLE
Add support for dosimeter

### DIFF
--- a/Sts1CobcSw/Edu/Edu.cpp
+++ b/Sts1CobcSw/Edu/Edu.cpp
@@ -41,6 +41,7 @@ namespace sts1cobcsw::edu
 // --- Public globals ---
 
 hal::GpioPin updateGpioPin(hal::eduUpdatePin);
+hal::GpioPin dosiEnableGpioPin(hal::dosiEnablePin);
 
 
 namespace

--- a/Sts1CobcSw/Edu/Edu.hpp
+++ b/Sts1CobcSw/Edu/Edu.hpp
@@ -9,6 +9,7 @@
 namespace sts1cobcsw::edu
 {
 extern hal::GpioPin updateGpioPin;
+extern hal::GpioPin dosiEnableGpioPin;
 
 
 auto Initialize() -> void;

--- a/Sts1CobcSw/Edu/Types.hpp
+++ b/Sts1CobcSw/Edu/Types.hpp
@@ -36,6 +36,8 @@ enum class StatusType : std::uint8_t
     noEvent,
     programFinished,
     resultsReady,
+    enableDosimeter,
+    disableDosimeter,
     invalid,
 };
 

--- a/Sts1CobcSw/Firmware/EduListenerThread.cpp
+++ b/Sts1CobcSw/Firmware/EduListenerThread.cpp
@@ -36,6 +36,7 @@ private:
     void init() override
     {
         edu::updateGpioPin.SetDirection(hal::PinDirection::in);
+        edu::dosiEnableGpioPin.SetDirection(hal::PinDirection::out);
     }
 
 
@@ -134,7 +135,15 @@ private:
                             break;
                         }
                         case edu::StatusType::enableDosimeter:
+                        {
+                            edu::dosiEnableGpioPin.Set();
+                            break;
+                        }
                         case edu::StatusType::disableDosimeter:
+                        {
+                            edu::dosiEnableGpioPin.Reset();
+                            break;
+                        }
                         case edu::StatusType::invalid:
                         case edu::StatusType::noEvent:
                         {

--- a/Sts1CobcSw/Firmware/EduListenerThread.cpp
+++ b/Sts1CobcSw/Firmware/EduListenerThread.cpp
@@ -133,6 +133,8 @@ private:
                                 edu::ProgramStatus::resultFileTransfered);
                             break;
                         }
+                        case edu::StatusType::enableDosimeter:
+                        case edu::StatusType::disableDosimeter:
                         case edu::StatusType::invalid:
                         case edu::StatusType::noEvent:
                         {


### PR DESCRIPTION
<!--
The PR title must be written as if it is the subject line of a commit that contains the entire PR code. See https://cbea.ms/git-commit/#seven-rules for how to write commit messages. If the PR fixes a single issue you can also use the issue title.
-->

### Description

- Added new status types `enableDosimeter` and `disableDosimeter` in file `Sts1CobcSw/Edu/Types.hpp`
- Added declaration of `edu::dosiEnableGpioPin` in `Edu.hpp`, definition in `Edu.cpp`.
- Modified `EduListenerThread.cpp` to :
   - Set `edu::dosiEnableGpioPin` direction to `out` in `init()` function.
   - Added the two new `StatusType` cases to the main switch so that `enableDosimeter` calls `dosiEnableGpioPin.Set()` and `disableDosimeter` calls `dosiEnableGpioPin.Reset()`.

<!-- Mention all issues that the PR fixes like so: -->
Fixes #406 
