### PR TITLE
Fix EDU commands test and dosimeter support

### DIFF
--- a/Sts1CobcSw/Edu/Edu.cpp
+++ b/Sts1CobcSw/Edu/Edu.cpp
@@ -369,6 +369,22 @@ auto ParseStatusData() -> Result<Status>
                       .programId = resultsReadyData.programId,
                       .startTime = resultsReadyData.startTime};
     }
+    if(statusId == EnableDosimeterData::id)
+    {
+        if(cepDataBuffer.size() != totalSerialSize<EnableDosimeterData>)
+        {
+            return ErrorCode::invalidLength;
+        }
+        return Status{.statusType = StatusType::enableDosimeter};
+    }
+    if(statusId == DisableDosimeterData::id)
+    {
+        if(cepDataBuffer.size() != totalSerialSize<DisableDosimeterData>)
+        {
+            return ErrorCode::invalidLength;
+        }
+        return Status{.statusType = StatusType::disableDosimeter};
+    }
     return ErrorCode::invalidStatusType;
 }
 

--- a/Sts1CobcSw/Edu/Types.hpp
+++ b/Sts1CobcSw/Edu/Types.hpp
@@ -133,6 +133,18 @@ struct ResultsReadyData
 };
 
 
+struct EnableDosimeterData
+{
+    static constexpr auto id = 0x03_b;
+};
+
+
+struct DisableDosimeterData
+{
+    static constexpr auto id = 0x04_b;
+};
+
+
 struct ResultInfo
 {
     bool eofIsReached = false;
@@ -200,6 +212,14 @@ inline constexpr std::size_t serialSize<edu::ResultsReadyData> =
                     decltype(edu::ResultsReadyData::programId),
                     decltype(edu::ResultsReadyData::startTime)>;
 
+template<>
+inline constexpr std::size_t serialSize<edu::EnableDosimeterData> =
+    totalSerialSize<decltype(edu::EnableDosimeterData::id)>;
+
+template<>
+inline constexpr std::size_t serialSize<edu::DisableDosimeterData> =
+    totalSerialSize<decltype(edu::DisableDosimeterData::id)>;
+
 
 namespace edu
 {
@@ -232,6 +252,11 @@ template<std::endian endianness>
 [[nodiscard]] auto DeserializeFrom(void const * source, ProgramFinishedData * data) -> void const *;
 template<std::endian endianness>
 [[nodiscard]] auto DeserializeFrom(void const * source, ResultsReadyData * data) -> void const *;
+template<std::endian endianness>
+[[nodiscard]] auto DeserializeFrom(void const * source, EnableDosimeterData * data) -> void const *;
+template<std::endian endianness>
+[[nodiscard]] auto DeserializeFrom(void const * source, DisableDosimeterData * data)
+    -> void const *;
 }
 }
 

--- a/Sts1CobcSw/Edu/Types.ipp
+++ b/Sts1CobcSw/Edu/Types.ipp
@@ -157,4 +157,28 @@ auto DeserializeFrom(void const * source, ResultsReadyData * data) -> void const
     source = DeserializeFrom<endianness>(source, &(data->startTime));
     return source;
 }
+
+
+template<std::endian endianness>
+auto DeserializeFrom(void const * source, [[maybe_unused]] EnableDosimeterData * data)
+    -> void const *
+{
+    using sts1cobcsw::DeserializeFrom;
+
+    auto dummy = EnableDosimeterData::id;
+    source = DeserializeFrom<endianness>(source, &dummy);
+    return source;
+}
+
+
+template<std::endian endianness>
+auto DeserializeFrom(void const * source, [[maybe_unused]] DisableDosimeterData * data)
+    -> void const *
+{
+    using sts1cobcsw::DeserializeFrom;
+
+    auto dummy = DisableDosimeterData::id;
+    source = DeserializeFrom<endianness>(source, &dummy);
+    return source;
+}
 }

--- a/Tests/ManualTests/EduCommands.test.cpp
+++ b/Tests/ManualTests/EduCommands.test.cpp
@@ -28,6 +28,8 @@ using RODOS::PRINTF;
 
 namespace
 {
+inline constexpr auto stackSize = 5000U;
+
 auto uciUart = RODOS::HAL_UART(hal::uciUartIndex, hal::uciUartTxPin, hal::uciUartRxPin);
 
 
@@ -35,7 +37,7 @@ template<std::size_t nCharacters>
 auto ReadCharacters() -> std::array<char, nCharacters>;
 
 
-class EduCommandsTest : public RODOS::StaticThread<>
+class EduCommandsTest : public RODOS::StaticThread<stackSize>
 {
 public:
     EduCommandsTest() : StaticThread("EduCommandsTest")
@@ -45,7 +47,6 @@ public:
 private:
     void init() override
     {
-        edu::Initialize();
         auto const baudRate = 115'200;
         hal::Initialize(&uciUart, baudRate);
     }
@@ -53,6 +54,7 @@ private:
 
     void run() override
     {
+        edu::Initialize();
         // Permanently turn on EDU for this test
         edu::TurnOn();
 

--- a/Tests/ManualTests/EduCommands.test.cpp
+++ b/Tests/ManualTests/EduCommands.test.cpp
@@ -14,7 +14,6 @@
 
 #include <array>
 #include <charconv>
-#include <cinttypes>
 #include <cstddef>
 #include <cstdint>
 #include <span>
@@ -77,8 +76,8 @@ private:
                 case 'u':
                 {
                     auto currentTime = CurrentRealTime();
-                    PRINTF("Sending UpdateTime(currentTime = %d)\n",
-                           static_cast<int>(value_of(currentTime)));
+                    PRINTF("Sending UpdateTime(currentTime = %u)\n",
+                           static_cast<unsigned>(value_of(currentTime)));
                     auto updateTimeResult = edu::UpdateTime({.currentTime = currentTime});
                     if(updateTimeResult.has_error())
                     {
@@ -92,26 +91,25 @@ private:
                 }
                 case 'e':
                 {
-                    PRINTF("Please enter a program ID (1 character)\n");
-                    auto userInput = ReadCharacters<1>();
+                    PRINTF("Please enter a program ID (3 characters)\n");
+                    auto userInput = ReadCharacters<3>();
                     auto programId = ProgramId(0);
                     std::from_chars(userInput.begin(), userInput.end(), value_of(programId));
 
-                    PRINTF("Please enter a start time (1 character)\n");
-                    userInput = ReadCharacters<1>();
+                    PRINTF("Please enter a start time (3 characters)\n");
+                    userInput = ReadCharacters<3>();
                     auto startTime = RealTime(0);
                     std::from_chars(userInput.begin(), userInput.end(), value_of(startTime));
 
-                    PRINTF("Please enter a timeout (1 character)\n");
-                    userInput = ReadCharacters<1>();
+                    PRINTF("Please enter a timeout (3 characters)\n");
+                    userInput = ReadCharacters<3>();
                     std::int16_t timeout = 0;
                     std::from_chars(userInput.begin(), userInput.end(), timeout);
 
                     PRINTF("\n");
-                    PRINTF("Sending ExecuteProgram(programId = %" PRIu16 ", startTime = %" PRIi32
-                           ", timeout = %" PRIi16 ")\n",
+                    PRINTF("Sending ExecuteProgram(programId = %u, startTime = %u, timeout = %d)\n",
                            value_of(programId),
-                           value_of(startTime),
+                           static_cast<unsigned>(value_of(startTime)),
                            timeout);
                     auto executeProgramResult = edu::ExecuteProgram(
                         {.programId = programId, .startTime = startTime, .timeout = timeout});
@@ -137,31 +135,29 @@ private:
                     {
                         auto status = getStatusResult.value();
                         PRINTF("  Status type = %d\n", static_cast<int>(status.statusType));
-                        PRINTF("  Program ID  = %d\n",
-                               static_cast<int>(value_of(status.programId)));
-                        PRINTF("  Start time  = %d\n",
-                               static_cast<int>(value_of(status.startTime)));
-                        PRINTF("  Exit code   = %d\n", static_cast<int>(status.exitCode));
+                        PRINTF("  Program ID  = %d\n", value_of(status.programId));
+                        PRINTF("  Start time  = %u\n",
+                               static_cast<unsigned>(value_of(status.startTime)));
+                        PRINTF("  Exit code   = %d\n", status.exitCode);
                     }
                     break;
                 }
                 case 'r':
                 {
-                    PRINTF("Please enter a program ID (1 character)\n");
-                    auto userInput = ReadCharacters<1>();
+                    PRINTF("Please enter a program ID (3 characters)\n");
+                    auto userInput = ReadCharacters<3>();
                     auto programId = ProgramId(0);
                     std::from_chars(userInput.begin(), userInput.end(), value_of(programId));
 
-                    PRINTF("Please enter a start time (1 character)\n");
-                    userInput = ReadCharacters<1>();
+                    PRINTF("Please enter a start time (3 characters)\n");
+                    userInput = ReadCharacters<3>();
                     auto startTime = RealTime(0);
                     std::from_chars(userInput.begin(), userInput.end(), value_of(startTime));
 
                     PRINTF("\n");
-                    PRINTF("Sending ReturnResult(programId = %" PRIu16 ", startTime = %" PRIi32
-                           ")\n",
+                    PRINTF("Sending ReturnResult(programId = %u, startTime = %u)\n",
                            value_of(programId),
-                           value_of(startTime));
+                           static_cast<unsigned>(value_of(startTime)));
                     auto returnResultResult = edu::ReturnResult(
                         edu::ReturnResultData{.programId = programId, .startTime = startTime});
                     if(returnResultResult.has_error())


### PR DESCRIPTION
Fixes #406 

I fixed the EDU commands test by moving the initialization of the EDU from the thread's `init()` to its `run()` function.

When implementing the dosimeter support the first time, we forgot to update the parse function for the status. I rectified this and some tests on the FlatSat showed that at least enabling the dosimeter is parsed and understood correctly (the programs never sent "disable dosimeter").