### PR TITLE
Remove real time offset correction

### DIFF
--- a/Sts1CobcSw/Firmware/RfCommunicationThread.cpp
+++ b/Sts1CobcSw/Firmware/RfCommunicationThread.cpp
@@ -882,9 +882,6 @@ auto GetValue(Parameter::Id parameterId) -> Parameter::Value
             return rf::GetRxDataRate();
         case Parameter::Id::txDataRate:
             return rf::GetTxDataRate();
-        case Parameter::Id::realTimeOffsetCorrection:
-            return static_cast<std::uint32_t>(persistentVariables.Load<"realTimeOffsetCorrection">()
-                                              / s);
         case Parameter::Id::maxEduIdleDuration:
             return static_cast<std::uint32_t>(persistentVariables.Load<"maxEduIdleDuration">() / s);
         case Parameter::Id::newEduResultIsAvailable:
@@ -905,9 +902,6 @@ auto Set(Parameter parameter) -> void
         case Parameter::Id::txDataRate:
             rf::SetTxDataRate(parameter.value);
             txDataRateTopic.publish(parameter.value);
-            break;
-        case Parameter::Id::realTimeOffsetCorrection:
-            persistentVariables.Store<"realTimeOffsetCorrection">(parameter.value * s);
             break;
         case Parameter::Id::maxEduIdleDuration:
             persistentVariables.Store<"maxEduIdleDuration">(parameter.value * s);

--- a/Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.cpp
+++ b/Sts1CobcSw/Firmware/StartupAndSpiSupervisorThread.cpp
@@ -80,7 +80,7 @@ private:
             RODOS::hwResetAndReboot();
         }
         InitializeAndFeedResetDog();
-        UpdateRealTimeOffset(persistentVariables.Load<"realTime">(), /*useOffsetCorrection=*/false);
+        UpdateRealTimeOffset(persistentVariables.Load<"realTime">());
         DEBUG_PRINT_REAL_TIME();
         SetUpFileSystem();
         edu::Initialize();

--- a/Sts1CobcSw/FramSections/FramLayout.hpp
+++ b/Sts1CobcSw/FramSections/FramLayout.hpp
@@ -40,7 +40,6 @@ inline constexpr auto persistentVariables =
                         PersistentVariableInfo<"antennasShouldBeDeployed", bool>,
                         PersistentVariableInfo<"realTime", RealTime>,
                         PersistentVariableInfo<"realTimeOffset", Duration>,
-                        PersistentVariableInfo<"realTimeOffsetCorrection", Duration>,
                         PersistentVariableInfo<"nFirmwareChecksumErrors", std::uint8_t>,
                         PersistentVariableInfo<"epsIsWorking", bool>,
                         PersistentVariableInfo<"flashIsWorking", bool>,

--- a/Sts1CobcSw/RealTime/RealTime.cpp
+++ b/Sts1CobcSw/RealTime/RealTime.cpp
@@ -5,7 +5,6 @@
 #include <Sts1CobcSw/RodosTime/RodosTime.hpp>
 
 #include <strong_type/affine_point.hpp>
-#include <strong_type/difference.hpp>
 #include <strong_type/type.hpp>
 
 #include <rodos_no_using_namespace.h>
@@ -15,13 +14,10 @@
 
 namespace sts1cobcsw
 {
-auto UpdateRealTimeOffset(RealTime realTime, bool useOffsetCorrection) -> void
+auto UpdateRealTimeOffset(RealTime realTime) -> void
 {
     auto currentRodosTime = CurrentRodosTime();
-    auto offsetCorrection =
-        useOffsetCorrection ? persistentVariables.Load<"realTimeOffsetCorrection">() : Duration(0);
-    auto newRealTimeOffset =
-        RodosTime(value_of(realTime) * RODOS::SECONDS) - currentRodosTime + offsetCorrection;
+    auto newRealTimeOffset = RodosTime(value_of(realTime) * RODOS::SECONDS) - currentRodosTime;
     persistentVariables.Store<"realTimeOffset">(newRealTimeOffset);
 }
 }

--- a/Sts1CobcSw/RealTime/RealTime.hpp
+++ b/Sts1CobcSw/RealTime/RealTime.hpp
@@ -14,7 +14,7 @@ namespace sts1cobcsw
 [[nodiscard]] auto CurrentRealTime() -> RealTime;
 [[nodiscard]] auto ToRodosTime(RealTime realTime) -> RodosTime;
 [[nodiscard]] auto ToRealTime(RodosTime rodosTime) -> RealTime;
-auto UpdateRealTimeOffset(RealTime realTime, bool useOffsetCorrection = true) -> void;
+auto UpdateRealTimeOffset(RealTime realTime) -> void;
 }
 
 

--- a/Sts1CobcSw/RfProtocols/Vocabulary.hpp
+++ b/Sts1CobcSw/RfProtocols/Vocabulary.hpp
@@ -17,7 +17,6 @@ struct Parameter
     {
         rxDataRate = 1,
         txDataRate,
-        realTimeOffsetCorrection,
         maxEduIdleDuration,
         newEduResultIsAvailable,
     };

--- a/Sts1CobcSw/RfProtocols/Vocabulary.ipp
+++ b/Sts1CobcSw/RfProtocols/Vocabulary.ipp
@@ -12,7 +12,6 @@ constexpr auto IsValid(Parameter::Id parameterId) -> bool
     {
         case Parameter::Id::rxDataRate:
         case Parameter::Id::txDataRate:
-        case Parameter::Id::realTimeOffsetCorrection:
         case Parameter::Id::maxEduIdleDuration:
         case Parameter::Id::newEduResultIsAvailable:
             return true;

--- a/Tests/SupportPrograms/FramExplorer.cpp
+++ b/Tests/SupportPrograms/FramExplorer.cpp
@@ -345,7 +345,6 @@ auto PrintAllVariables() -> void
     PrintVariable("antennasShouldBeDeployed");
     PrintVariable("realTime");
     PrintVariable("realTimeOffset");
-    PrintVariable("realTimeOffsetCorrection");
     PrintVariable("nFirmwareChecksumErrors");
     PrintVariable("epsIsWorking");
     PrintVariable("flashIsWorking");
@@ -385,7 +384,6 @@ auto ResetAllVariables() -> void
     persistentVariables.Store<"antennasShouldBeDeployed">(false);
     persistentVariables.Store<"realTime">(RealTime(0));
     persistentVariables.Store<"realTimeOffset">(Duration(0));
-    persistentVariables.Store<"realTimeOffsetCorrection">(Duration(0));
     persistentVariables.Store<"nFirmwareChecksumErrors">(0);
     persistentVariables.Store<"epsIsWorking">(false);
     persistentVariables.Store<"flashIsWorking">(false);
@@ -454,10 +452,6 @@ auto PrintVariable(etl::string_view variable) -> void  // NOLINT(*value-param)
     else if(variable == "realTimeOffset")
     {
         etl::to_string(value_of(persistentVariables.Load<"realTimeOffset">()), value);
-    }
-    else if(variable == "realTimeOffsetCorrection")
-    {
-        etl::to_string(value_of(persistentVariables.Load<"realTimeOffsetCorrection">()), value);
     }
     else if(variable == "nFirmwareChecksumErrors")
     {
@@ -598,11 +592,6 @@ auto SetVariable(etl::string_view variable, etl::string_view value) -> void  // 
     else if(variable == "realTimeOffset")
     {
         WriteAndConvertFunction<"realTimeOffset", Duration, ParseAsInt64>(variable, value);
-    }
-    else if(variable == "realTimeOffsetCorrection")
-    {
-        WriteAndConvertFunction<"realTimeOffsetCorrection", Duration, ParseAsInt64>(variable,
-                                                                                    value);
     }
     else if(variable == "nFirmwareChecksumErrors")
     {

--- a/Tests/UnitTests/Requests.test.cpp
+++ b/Tests/UnitTests/Requests.test.cpp
@@ -210,36 +210,34 @@ TEST_CASE("PerformAFunctionRequest")
 TEST_CASE("ReportParameterValuesRequest")
 {
     auto buffer = etl::vector<Byte, sts1cobcsw::tc::maxPacketLength>{};
-    buffer.resize(6);
-    buffer[0] = 0x05_b;  // Number of ParameterIDs
+    buffer.resize(5);
+    buffer[0] = 0x04_b;  // Number of ParameterIDs
     buffer[1] = 0x01_b;  // ParameterID 1
     buffer[2] = 0x02_b;  // ParameterID 2
     buffer[3] = 0x03_b;  // ParameterID 3
     buffer[4] = 0x04_b;  // ParameterID 4
-    buffer[5] = 0x05_b;  // ParameterID 5
 
     auto parseResult = sts1cobcsw::ParseAsReportParameterValuesRequest(buffer);
     REQUIRE(parseResult.has_value());
     auto const & request = parseResult.value();
 
-    CHECK(request.nParameters == 0x05);
+    CHECK(request.nParameters == 0x04);
     CHECK(request.parameterIds[0] == sts1cobcsw::Parameter::Id::rxDataRate);
     CHECK(request.parameterIds[1] == sts1cobcsw::Parameter::Id::txDataRate);
-    CHECK(request.parameterIds[2] == sts1cobcsw::Parameter::Id::realTimeOffsetCorrection);
-    CHECK(request.parameterIds[3] == sts1cobcsw::Parameter::Id::maxEduIdleDuration);
-    CHECK(request.parameterIds[4] == sts1cobcsw::Parameter::Id::newEduResultIsAvailable);
+    CHECK(request.parameterIds[2] == sts1cobcsw::Parameter::Id::maxEduIdleDuration);
+    CHECK(request.parameterIds[3] == sts1cobcsw::Parameter::Id::newEduResultIsAvailable);
 
     // No more than 5 Parameters are allowed
     buffer[0] = 0x06_b;
     parseResult = sts1cobcsw::ParseAsReportParameterValuesRequest(buffer);
     CHECK(parseResult.has_error());
     CHECK(parseResult.error() == ErrorCode::invalidApplicationData);
-    buffer[0] = 0x05_b;
+    buffer[0] = 0x04_b;
 
-    // For 5 Parameter, a buffer of 6 is required
+    // For 4 Parameter, a buffer of 5 is required
     auto smallerBuffer = etl::vector<Byte, 5>{};
-    smallerBuffer.resize(5);
-    smallerBuffer[0] = 0x05_b;  // Number of ParameterIDs
+    smallerBuffer.resize(4);
+    smallerBuffer[0] = 0x04_b;  // Number of ParameterIDs
     smallerBuffer[1] = 0x01_b;  // ParameterID 1
     smallerBuffer[2] = 0x02_b;  // ParameterID 2
     smallerBuffer[3] = 0x03_b;  // ParameterID 3
@@ -260,8 +258,8 @@ TEST_CASE("ReportParameterValuesRequest")
 TEST_CASE("SetParameterValuesRequest")
 {
     auto buffer = etl::vector<Byte, sts1cobcsw::tc::maxPacketLength>{};
-    buffer.resize(26);
-    buffer[0] = 0x05_b;   // Number of ParameterIDs
+    buffer.resize(21);
+    buffer[0] = 0x04_b;   // Number of ParameterIDs
     buffer[1] = 0x01_b;   // ParameterId 1
     buffer[2] = 0xAA_b;   // ParameterValue 1 (high byte)
     buffer[3] = 0xBB_b;   // ParameterValue 1
@@ -274,13 +272,12 @@ TEST_CASE("SetParameterValuesRequest")
     buffer[10] = 0xEE_b;  // ParameterValue 2 (low byte)
     buffer[11] = 0x03_b;  // ParameterId 3
     buffer[16] = 0x04_b;  // ParameterId 4
-    buffer[21] = 0x05_b;  // ParameterId 5
 
     auto parseResult = sts1cobcsw::ParseAsSetParameterValuesRequest(buffer);
     CHECK(parseResult.has_value());
     auto request = parseResult.value();
 
-    CHECK(request.nParameters == 0x05);
+    CHECK(request.nParameters == 0x04);
     CHECK(request.parameters[0].id == sts1cobcsw::Parameter::Id::rxDataRate);
     CHECK(request.parameters[0].value == 0xAABB'CCDD);
     CHECK(request.parameters[1].id == sts1cobcsw::Parameter::Id::txDataRate);
@@ -298,12 +295,12 @@ TEST_CASE("SetParameterValuesRequest")
     parseResult = sts1cobcsw::ParseAsSetParameterValuesRequest(buffer);
     CHECK(parseResult.has_error());
     CHECK(parseResult.error() == ErrorCode::invalidApplicationData);
-    buffer[0] = 0x05_b;
+    buffer[0] = 0x04_b;
 
-    // For 5 Parameter, a buffer of 26 is required
-    auto smallerBuffer = etl::vector<Byte, 25>{};
-    smallerBuffer.resize(25);
-    smallerBuffer[0] = 0x05_b;  // Number of ParameterIDs
+    // For 4 Parameter, a buffer of 25 is required
+    auto smallerBuffer = etl::vector<Byte, 24>{};
+    smallerBuffer.resize(24);
+    smallerBuffer[0] = 0x04_b;  // Number of ParameterIDs
     parseResult = sts1cobcsw::ParseAsSetParameterValuesRequest(smallerBuffer);
     CHECK(parseResult.has_error());
     CHECK(parseResult.error() == ErrorCode::invalidDataLength);


### PR DESCRIPTION
The parameter `realTimeOffsetCorrection` made synchronizing the real time surprising, confusing, and even unreliable. Since we increased our default RF data rate from 1200 Bd to 9600 Bd, the correction is also less useful.